### PR TITLE
Upgrade to `emsdk` 4.0.9

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@ bundle = "run -p perspective-bundle"
 
 [build]
 # rustflags = ["--cfg=web_sys_unstable_apis", "--cfg=pyo3_disable_reference_pool"]
-rustflags = ["--cfg=web_sys_unstable_apis"]
+rustflags = ["--cfg=web_sys_unstable_apis", "-Csymbol-mangling-version=v0"]
 target-dir = "rust/target"
 
 [target.wasm32-unknown-unknown]

--- a/examples/blocks/package.json
+++ b/examples/blocks/package.json
@@ -4,7 +4,7 @@
     "version": "3.8.0",
     "description": "A collection of simple client-side Perspective examples for `http://bl.ocks.org`.",
     "scripts": {
-        "start": "mkdir -p dist && node --experimental-wasm-memory64 --experimental-modules server.mjs",
+        "start": "mkdir -p dist && node --experimental-modules server.mjs",
         "repl": "node --experimental-repl-await"
     },
     "main": "index.mjs",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
         }
     },
     "type": "module",
-    "emscripten": "3.1.58",
+    "emscripten": "4.0.9",
     "llvm": "17.0.6",
-    "pyodide": "0.27.1",
+    "pyodide": "0.28.3",
     "engines": {
         "node": ">=16 <23"
     },

--- a/rust/perspective-python/requirements-pyodide.txt
+++ b/rust/perspective-python/requirements-pyodide.txt
@@ -1,5 +1,5 @@
 # Requirements for testing pyodide
 pytest==8.2.2
 pytest-playwright==0.5.2
-pytest-pyodide==0.58.4
+pytest-pyodide==0.58.6
 pytest-timeout==2.3.1

--- a/rust/perspective-python/test.mjs
+++ b/rust/perspective-python/test.mjs
@@ -24,14 +24,14 @@ if (process.env.PSP_PYODIDE) {
     const pyodideDistDir = getPyodideDistDir();
     if (!fs.existsSync(pyodideDistDir)) {
         console.error(
-            `Error: Pyodide distribution not found at ${pyodideDistDir}\n\nRun: pnpm -w run install_pyodide\n\n`
+            `Error: Pyodide distribution not found at ${pyodideDistDir}\n\nRun: pnpm -w run install_pyodide\n\n`,
         );
         process.exit(1);
     }
     const emscriptenWheel = getEmscriptenWheelPath();
     if (!fs.existsSync(emscriptenWheel)) {
         console.error(
-            `Error: Emscripten wheel not found at ${emscriptenWheel}\n\nRun: pnpm run build\n\n`
+            `Error: Emscripten wheel not found at ${emscriptenWheel}\n\nRun: pnpm run build\n\n`,
         );
         process.exit(1);
     }
@@ -48,9 +48,9 @@ if (process.env.PSP_PYODIDE) {
             // with --timeout_method=signal, tests hang.  seems like the
             // pytest-pyodide webserver fixture does not shut down
             "--timeout_method=thread",
-            // ...process.argv.slice(2),
+            ...process.argv.slice(2),
         ],
-        execOpts
+        execOpts,
     );
 } else {
     execFileSync(
@@ -59,8 +59,8 @@ if (process.env.PSP_PYODIDE) {
             "perspective/tests",
             "-W error",
             "--timeout=300",
-            // ...process.argv.slice(2),
+            ...process.argv.slice(2),
         ],
-        execOpts
+        execOpts,
     );
 }

--- a/rust/perspective-server/cpp/perspective/CMakeLists.txt
+++ b/rust/perspective-server/cpp/perspective/CMakeLists.txt
@@ -345,7 +345,7 @@ endif()
 set(RAPIDJSON_BUILD_TESTS OFF CACHE BOOL "Disable rapidjson tests")
 
 if(PSP_PYODIDE)
-    set(RELOCATABLE_FLAGS " -sRELOCATABLE=1 -sSIDE_MODULE=2 ")
+    set(RELOCATABLE_FLAGS " -sRELOCATABLE=1 -sSIDE_MODULE=2 -fwasm-exceptions -sSUPPORT_LONGJMP=wasm \ ")
     string(APPEND CMAKE_EXE_LINKER_FLAGS "${RELOCATABLE_FLAGS} -sWASM_BIGINT=1 ")
     string(APPEND CMAKE_C_FLAGS "${RELOCATABLE_FLAGS}")
     string(APPEND CMAKE_CXX_FLAGS "${RELOCATABLE_FLAGS}")
@@ -355,10 +355,10 @@ if(PSP_PYODIDE)
     string(APPEND CMAKE_CXX_FLAGS " -fvisibility=hidden")
 endif()
 
-if (PSP_PYODIDE AND NOT PSP_WASM_EXCEPTIONS)
-    # Emscripten exceptions
-    string(APPEND CMAKE_CXX_FLAGS " -fexceptions")
-endif()
+# if (PSP_PYODIDE AND NOT PSP_WASM_EXCEPTIONS)
+#     # Emscripten exceptions
+#     string(APPEND CMAKE_CXX_FLAGS " -fexceptions")
+# endif()
 
 # Build (read: download and extract) header-only dependencies from external sources
 set(all_deps_INCLUDE_DIRS "")

--- a/tools/perspective-scripts/workspace.mjs
+++ b/tools/perspective-scripts/workspace.mjs
@@ -39,7 +39,7 @@ export function getRustWheelsDir() {
 }
 export function getEmscriptenWheelPath() {
     const pspVersion = getWorkspacePackageJson().version.replace("-", ".");
-    const wheeljunk = "cp39-abi3-emscripten_3_1_58_wasm32";
+    const wheeljunk = "cp39-abi3-emscripten_4_0_9_wasm32";
     return path.join(
         rustWheelsDir,
         `perspective_python-${pspVersion}-${wheeljunk}.whl`,


### PR DESCRIPTION
This PR is not ready to merge.

In order to build for `pyodide`, we must use the same `emscripten` ABI version as they do. This has recently been upgraded to `4.0.9` (from `3.1.58`), but the pyodide version which supports this ABI (`0.28.x`) deprecates `pyarrow` and `polars` (or rather - decouples their compatibility from the pyodide release itself). Ergo, while this PR can compile, we cannot test it yet.