### PR TITLE
Add `View::with_typed_arrays` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,6 +2121,9 @@ name = "perspective-js"
 version = "4.4.1"
 dependencies = [
  "anyhow",
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
  "bytes",
  "chrono",
  "derivative",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1218,6 +1218,12 @@ importers:
       perspective-4-2-0:
         specifier: npm:@perspective-dev/client@4.2.0
         version: '@perspective-dev/client@4.2.0'
+      perspective-4-3-0:
+        specifier: npm:@perspective-dev/client@4.3.0
+        version: '@perspective-dev/client@4.3.0'
+      perspective-4-4-0:
+        specifier: npm:@perspective-dev/client@4.4.0
+        version: '@perspective-dev/client@4.4.0'
     devDependencies:
       '@perspective-dev/client':
         specifier: 'workspace:'
@@ -2189,8 +2195,17 @@ packages:
   '@perspective-dev/client@4.2.0':
     resolution: {integrity: sha512-Gb9RFOoKnGAJDR0rZA9OBC8CY3Sv3zsEJfrmUhmnFWC21erk66DhppFXKYm3ggU2ob/yhCNA/yWMUv4n8OBqVQ==}
 
+  '@perspective-dev/client@4.3.0':
+    resolution: {integrity: sha512-LhVDyYzZrSmtuU04qX+MzpnA1BKPEW9nMi4RPE6y3KiGAWwFFqEFgZKF233U8/Fx3v2URCijcwmXn0qTVfoPMQ==}
+
+  '@perspective-dev/client@4.4.0':
+    resolution: {integrity: sha512-AvfWskJJbfOZl6k2Gfntw/c2a+KDnCy5GfDvEQohdXUNMg+0uec//QuL0ZaqclQA/WfRvm4k+YHIUiBhT8EYew==}
+
   '@perspective-dev/server@4.3.0':
     resolution: {integrity: sha512-UH3ADscynozVx42RF07DTBmPE/0PUwH+SS0cgvMLuLfBjtvnPm6msfOU0tHlgFnNZOHJO0q6RZ9WI5fD6wF07A==}
+
+  '@perspective-dev/server@4.4.1':
+    resolution: {integrity: sha512-eOWr0qy2T2KwClbYgRjfDrcnkR023gHn/7J/tQEPa6rEYTfqXwicWsObFU4mZHi3rTySxYf6qsY6O+SJIM+BzA==}
 
   '@playwright/experimental-ct-core@1.58.0':
     resolution: {integrity: sha512-YZsjApZmRE78Kp2E6OtAvFFVheUyZDfrlZMf+lfnSshmYHrrJUy3bhdCe7EPCWsE12XfCVVAv6G0btiyAx8d0w==}
@@ -6904,7 +6919,33 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@perspective-dev/client@4.3.0':
+    dependencies:
+      '@perspective-dev/server': 4.4.1
+      pro_self_extracting_wasm: 0.0.9
+      stoppable: 1.1.0
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@perspective-dev/client@4.4.0':
+    dependencies:
+      '@perspective-dev/server': 4.4.1
+      pro_self_extracting_wasm: 0.0.9
+      stoppable: 1.1.0
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
   '@perspective-dev/server@4.3.0': {}
+
+  '@perspective-dev/server@4.4.1': {}
 
   '@playwright/experimental-ct-core@1.58.0(@types/node@24.9.1)(jiti@1.21.7)(less@4.4.2)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)':
     dependencies:

--- a/rust/metadata/main.rs
+++ b/rust/metadata/main.rs
@@ -35,6 +35,7 @@ use perspective_client::{
     ColumnWindow, DeleteOptions, JoinOptions, OnUpdateData, OnUpdateOptions, SystemInfo,
     TableInitOptions, UpdateOptions, ViewWindow,
 };
+use perspective_js::TypedArrayWindow;
 use perspective_viewer::config::{ViewerConfig, ViewerConfigUpdate};
 use ts_rs::TS;
 
@@ -67,17 +68,18 @@ pub fn generate_type_bindings_js() -> Result<(), Box<dyn Error>> {
     let path = std::env::current_dir()?.join("../perspective-js/src/ts/ts-rs");
     ColumnType::export_all_to(&path)?;
     ColumnWindow::export_all_to(&path)?;
-    ViewWindow::export_all_to(&path)?;
-    TableInitOptions::export_all_to(&path)?;
-    ViewConfigUpdate::export_all_to(&path)?;
+    DeleteOptions::export_all_to(&path)?;
+    JoinOptions::export_all_to(&path)?;
     OnUpdateData::export_all_to(&path)?;
     OnUpdateOptions::export_all_to(&path)?;
-    JoinOptions::export_all_to(&path)?;
-    UpdateOptions::export_all_to(&path)?;
-    DeleteOptions::export_all_to(&path)?;
-    ViewWindow::export_all_to(&path)?;
     SystemInfo::<f64>::export_all_to(&path)?;
+    TableInitOptions::export_all_to(&path)?;
+    TypedArrayWindow::export_all_to(&path)?;
+    UpdateOptions::export_all_to(&path)?;
     ViewConfig::export_all_to(&path)?;
+    ViewConfigUpdate::export_all_to(&path)?;
+    ViewWindow::export_all_to(&path)?;
+    ViewWindow::export_all_to(&path)?;
     Ok(())
 }
 

--- a/rust/perspective-client/perspective.proto
+++ b/rust/perspective-client/perspective.proto
@@ -86,6 +86,7 @@ message ViewPort {
     optional uint32 start_col = 2;
     optional uint32 end_row = 3;
     optional uint32 end_col = 4;
+    optional bool emit_legacy_row_path_names = 5;
 //   optional bool id = 5;
 //   optional bool index = 3;
 //   optional bool formatted = 6;

--- a/rust/perspective-client/src/rust/view.rs
+++ b/rust/perspective-client/src/rust/view.rs
@@ -109,6 +109,13 @@ pub struct ViewWindow {
     #[ts(optional)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compression: Option<String>,
+
+    /// When `true`, group-by columns use legacy `"colname (Group by N)"`
+    /// naming. When `false`, they use `__ROW_PATH_N__` naming consistent
+    /// with the SQL backend. Defaults to `true` for backwards compatibility.
+    #[ts(optional)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub emit_legacy_row_path_names: Option<bool>,
 }
 
 impl From<ViewWindow> for ViewPort {
@@ -118,6 +125,7 @@ impl From<ViewWindow> for ViewPort {
             start_col: window.start_col.map(|x| x.floor() as u32),
             end_row: window.end_row.map(|x| x.ceil() as u32),
             end_col: window.end_col.map(|x| x.ceil() as u32),
+            emit_legacy_row_path_names: window.emit_legacy_row_path_names,
         }
     }
 }
@@ -129,6 +137,7 @@ impl From<ViewPort> for ViewWindow {
             start_col: window.start_col.map(|x| x as f64),
             end_row: window.end_row.map(|x| x as f64),
             end_col: window.end_col.map(|x| x as f64),
+            emit_legacy_row_path_names: window.emit_legacy_row_path_names,
             ..ViewWindow::default()
         }
     }

--- a/rust/perspective-client/src/rust/virtual_server/data.rs
+++ b/rust/perspective-client/src/rust/virtual_server/data.rs
@@ -14,12 +14,15 @@ use std::error::Error;
 use std::sync::Arc;
 
 use arrow_array::builder::{
-    BooleanBuilder, Float64Builder, Int32Builder, StringBuilder, TimestampMillisecondBuilder,
+    BooleanBuilder, Float64Builder, Int32Builder, StringDictionaryBuilder,
+    TimestampMillisecondBuilder,
 };
+use arrow_array::cast::AsArray;
+use arrow_array::types::Int32Type;
 use arrow_array::{
-    Array, ArrayRef, BooleanArray, Date32Array, Date64Array, Decimal128Array, Float32Array,
-    Float64Array, Int8Array, Int16Array, Int32Array, Int64Array, LargeStringArray, RecordBatch,
-    StringArray, Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray,
+    Array, ArrayAccessor, ArrayRef, BooleanArray, Date32Array, Date64Array, Decimal128Array,
+    Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array, LargeStringArray,
+    RecordBatch, StringArray, Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray,
     Time64NanosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray,
     TimestampNanosecondArray, TimestampSecondArray, UInt8Array, UInt16Array, UInt32Array,
     UInt64Array,
@@ -36,10 +39,14 @@ use crate::config::{GroupRollupMode, Scalar, ViewConfig};
 /// [`VirtualDataSlice`].
 pub enum ColumnBuilder {
     Boolean(BooleanBuilder),
-    String(StringBuilder),
+    String(StringDictionaryBuilder<Int32Type>),
     Float(Float64Builder),
     Integer(Int32Builder),
     Datetime(TimestampMillisecondBuilder),
+}
+
+fn dict_data_type() -> DataType {
+    DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8))
 }
 
 /// A single cell value in a row-oriented data representation.
@@ -90,7 +97,7 @@ impl SetVirtualDataColumn for Option<String> {
     }
 
     fn new_builder() -> ColumnBuilder {
-        ColumnBuilder::String(StringBuilder::new())
+        ColumnBuilder::String(StringDictionaryBuilder::new())
     }
 
     fn to_scalar(self) -> Scalar {
@@ -277,6 +284,11 @@ fn extract_scalar(array: &ArrayRef, row_idx: usize) -> Scalar {
             let arr = array.as_any().downcast_ref::<StringArray>().unwrap();
             Scalar::String(arr.value(row_idx).to_string())
         },
+        DataType::Dictionary(..) => {
+            let dict = array.as_dictionary::<Int32Type>();
+            let values = dict.downcast_dict::<StringArray>().unwrap();
+            Scalar::String(values.value(row_idx).to_string())
+        },
         DataType::Float64 => {
             let arr = array.as_any().downcast_ref::<Float64Array>().unwrap();
             Scalar::Float(arr.value(row_idx))
@@ -350,14 +362,26 @@ fn coerce_column(
     array: &ArrayRef,
 ) -> Result<(Field, ArrayRef), Box<dyn Error>> {
     match field.data_type() {
-        DataType::Boolean
-        | DataType::Utf8
-        | DataType::Float64
-        | DataType::Int32
-        | DataType::Date32 => Ok((
+        DataType::Boolean | DataType::Float64 | DataType::Int32 | DataType::Date32 => Ok((
             Field::new(name, field.data_type().clone(), true),
             array.clone(),
         )),
+        DataType::Dictionary(..) => Ok((Field::new(name, dict_data_type(), true), array.clone())),
+        DataType::Utf8 => {
+            let arr = array.as_any().downcast_ref::<StringArray>().unwrap();
+            let mut builder = StringDictionaryBuilder::<Int32Type>::new();
+            for i in 0..arr.len() {
+                if arr.is_null(i) {
+                    builder.append_null();
+                } else {
+                    builder.append_value(arr.value(i));
+                }
+            }
+            Ok((
+                Field::new(name, dict_data_type(), true),
+                Arc::new(builder.finish()) as ArrayRef,
+            ))
+        },
         DataType::Timestamp(TimeUnit::Millisecond, _) => Ok((
             Field::new(name, DataType::Timestamp(TimeUnit::Millisecond, None), true),
             array.clone(),
@@ -502,20 +526,27 @@ fn coerce_column(
         },
         DataType::LargeUtf8 => {
             let arr = array.as_any().downcast_ref::<LargeStringArray>().unwrap();
-            let result: StringArray = arr.iter().map(|v| v.map(|v| v.to_string())).collect();
+            let mut builder = StringDictionaryBuilder::<Int32Type>::new();
+            for i in 0..arr.len() {
+                if arr.is_null(i) {
+                    builder.append_null();
+                } else {
+                    builder.append_value(arr.value(i));
+                }
+            }
             Ok((
-                Field::new(name, DataType::Utf8, true),
-                Arc::new(result) as ArrayRef,
+                Field::new(name, dict_data_type(), true),
+                Arc::new(builder.finish()) as ArrayRef,
             ))
         },
         dt => {
             tracing::warn!(
-                "Coercing unknown Arrow type {} to Utf8 for column '{}'",
+                "Coercing unknown Arrow type {} to Dictionary for column '{}'",
                 dt,
                 name
             );
             let num_rows = array.len();
-            let mut builder = StringBuilder::new();
+            let mut builder = StringDictionaryBuilder::<Int32Type>::new();
             for i in 0..num_rows {
                 if array.is_null(i) {
                     builder.append_null();
@@ -525,7 +556,7 @@ fn coerce_column(
                 }
             }
             Ok((
-                Field::new(name, DataType::Utf8, true),
+                Field::new(name, dict_data_type(), true),
                 Arc::new(builder.finish()) as ArrayRef,
             ))
         },
@@ -667,9 +698,10 @@ impl VirtualDataSlice {
                         Field::new(name, DataType::Boolean, true),
                         Arc::new(b.finish()),
                     ),
-                    ColumnBuilder::String(b) => {
-                        (Field::new(name, DataType::Utf8, true), Arc::new(b.finish()))
-                    },
+                    ColumnBuilder::String(b) => (
+                        Field::new(name, dict_data_type(), true),
+                        Arc::new(b.finish()),
+                    ),
                     ColumnBuilder::Float(b) => (
                         Field::new(name, DataType::Float64, true),
                         Arc::new(b.finish()),
@@ -736,7 +768,9 @@ impl VirtualDataSlice {
                     let cell = if col.is_null(row_idx) {
                         match field.data_type() {
                             DataType::Boolean => VirtualDataCell::Boolean(None),
-                            DataType::Utf8 => VirtualDataCell::String(None),
+                            DataType::Utf8 | DataType::Dictionary(..) => {
+                                VirtualDataCell::String(None)
+                            },
                             DataType::Float64 => VirtualDataCell::Float(None),
                             DataType::Int32 => VirtualDataCell::Integer(None),
                             DataType::Timestamp(TimeUnit::Millisecond, _) => {
@@ -753,6 +787,11 @@ impl VirtualDataSlice {
                             DataType::Utf8 => {
                                 let arr = col.as_any().downcast_ref::<StringArray>().unwrap();
                                 VirtualDataCell::String(Some(arr.value(row_idx).to_string()))
+                            },
+                            DataType::Dictionary(..) => {
+                                let dict = col.as_dictionary::<Int32Type>();
+                                let values = dict.downcast_dict::<StringArray>().unwrap();
+                                VirtualDataCell::String(Some(values.value(row_idx).to_string()))
                             },
                             DataType::Float64 => {
                                 let arr = col.as_any().downcast_ref::<Float64Array>().unwrap();
@@ -827,6 +866,21 @@ impl VirtualDataSlice {
                                     None
                                 } else {
                                     Some(arr.value(i))
+                                }
+                            })
+                            .collect::<Vec<_>>(),
+                    )?
+                },
+                DataType::Dictionary(..) => {
+                    let dict = col.as_dictionary::<Int32Type>();
+                    let values = dict.downcast_dict::<StringArray>().unwrap();
+                    serde_json::to_value(
+                        (0..num_rows)
+                            .map(|i| {
+                                if col.is_null(i) {
+                                    None
+                                } else {
+                                    Some(values.value(i))
                                 }
                             })
                             .collect::<Vec<_>>(),

--- a/rust/perspective-client/src/rust/virtual_server/generic_sql_model/tests.rs
+++ b/rust/perspective-client/src/rust/virtual_server/generic_sql_model/tests.rs
@@ -311,6 +311,7 @@ fn test_view_get_data_col_sort_ascending() {
         end_row: Some(100),
         start_col: Some(0),
         end_col: None,
+        ..ViewPort::default()
     };
 
     let mut schema = IndexMap::new();
@@ -341,6 +342,7 @@ fn test_view_get_data_col_sort_descending() {
         end_row: Some(100),
         start_col: Some(0),
         end_col: None,
+        ..ViewPort::default()
     };
 
     let mut schema = IndexMap::new();
@@ -370,6 +372,7 @@ fn test_view_get_data() {
         end_row: Some(100),
         start_col: Some(0),
         end_col: Some(5),
+        ..ViewPort::default()
     };
 
     let mut schema = IndexMap::new();
@@ -536,6 +539,7 @@ fn test_view_get_data_flat_no_grouping_id() {
         end_row: Some(100),
         start_col: Some(0),
         end_col: None,
+        ..ViewPort::default()
     };
 
     let mut schema = IndexMap::new();

--- a/rust/perspective-js/Cargo.toml
+++ b/rust/perspective-js/Cargo.toml
@@ -64,6 +64,9 @@ wasm-bindgen-test = "0.3.13"
 
 [dependencies]
 perspective-client = { version = "4.4.1", features = ["sendable"] }
+arrow-array = { version = "57.3.0", default-features = false }
+arrow-ipc = { version = "57.3.0", default-features = false }
+arrow-schema = { version = "57.3.0", default-features = false }
 bytes = "1.10.1"
 chrono = "0.4"
 derivative = "2.2.0"

--- a/rust/perspective-js/src/rust/lib.rs
+++ b/rust/perspective-js/src/rust/lib.rs
@@ -29,6 +29,7 @@ mod client;
 mod generic_sql_model;
 mod table;
 mod table_data;
+mod typed_array;
 pub mod utils;
 mod view;
 mod virtual_server;
@@ -40,6 +41,7 @@ pub use crate::client::Client;
 pub use crate::generic_sql_model::*;
 pub use crate::table::*;
 pub use crate::table_data::*;
+pub use crate::typed_array::*;
 pub use crate::virtual_server::*;
 
 #[cfg(feature = "export-init")]
@@ -61,10 +63,12 @@ export type * from "../../src/ts/ts-rs/Filter.d.ts";
 export type * from "../../src/ts/ts-rs/ViewConfig.d.ts";
 export type * from "../../src/ts/ts-rs/JoinOptions.ts";
 export type * from "../../src/ts/ts-rs/JoinType.ts";
+export type * from "../../src/ts/ts-rs/TypedArrayWindow.ts";
 
 import type {ColumnWindow} from "../../src/ts/ts-rs/ColumnWindow.d.ts";
 import type {ColumnType} from "../../src/ts/ts-rs/ColumnType.d.ts";
 import type {ViewWindow} from "../../src/ts/ts-rs/ViewWindow.d.ts";
+import type {TypedArrayWindow} from "../../src/ts/ts-rs/TypedArrayWindow.ts";
 import type {TableInitOptions} from "../../src/ts/ts-rs/TableInitOptions.d.ts";
 import type {JoinOptions} from "../../src/ts/ts-rs/JoinOptions.ts";
 import type {JoinType} from "../../src/ts/ts-rs/JoinType.ts";

--- a/rust/perspective-js/src/rust/typed_array.rs
+++ b/rust/perspective-js/src/rust/typed_array.rs
@@ -1,0 +1,240 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+use std::io::Cursor;
+
+use arrow_array::Array as _;
+use arrow_array::cast::AsArray;
+use arrow_array::types::*;
+use arrow_ipc::reader::StreamReader;
+use arrow_schema::{DataType, TimeUnit};
+use js_sys::{Array, Function, JsString, Uint8Array};
+use perspective_client::ViewWindow;
+use ts_rs::TS;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+unsafe extern "C" {
+    #[wasm_bindgen(typescript_type = "TypedArrayWindow")]
+    #[derive(Clone)]
+    pub type JsTypedArrayWindow;
+}
+
+/// Options for `with_typed_arrays`, extending `ViewWindow` with
+/// typed-array-specific options.
+#[derive(Default, serde::Deserialize, TS)]
+pub struct TypedArrayWindow {
+    #[serde(flatten)]
+    pub view_window: ViewWindow,
+
+    /// When `true`, Float64/Date32/Timestamp columns are output as
+    /// `Float32Array` instead of `Float64Array`.
+    #[serde(default)]
+    pub float32: bool,
+}
+
+impl From<TypedArrayWindow> for ViewWindow {
+    fn from(w: TypedArrayWindow) -> Self {
+        w.view_window
+    }
+}
+
+/// Decode an Arrow IPC batch and call `callback` once with all columns.
+///
+/// Callback signature:
+/// ```js
+/// callback(names: string[], values: TypedArray[], validities: (Uint8Array|null)[], dictionaries: (string[]|null)[])
+/// ```
+pub(crate) fn decode_and_call(
+    arrow: &[u8],
+    float32: bool,
+    callback: &Function,
+) -> Result<(), JsValue> {
+    let cursor = Cursor::new(arrow);
+    let reader = StreamReader::try_new(cursor, None)
+        .map_err(|e| JsValue::from_str(&format!("Arrow decode error: {e}")))?;
+
+    let batch = reader
+        .into_iter()
+        .next()
+        .ok_or_else(|| JsValue::from_str("Arrow IPC contained no record batches"))?
+        .map_err(|e| JsValue::from_str(&format!("Arrow batch error: {e}")))?;
+
+    let schema = batch.schema();
+    let num_cols = batch.num_columns();
+
+    let js_names = Array::new_with_length(num_cols as u32);
+    let js_values = Array::new_with_length(num_cols as u32);
+    let js_validities = Array::new_with_length(num_cols as u32);
+    let js_dicts = Array::new_with_length(num_cols as u32);
+
+    // Storage for allocated conversion buffers. These MUST outlive the
+    // callback because `js_sys::*Array::view()` creates zero-copy views
+    // into their heap memory. Using `Box<[T]>` (rather than `Vec<T>`)
+    // yields a stable pointer that won't move when the outer Vec grows.
+    let mut f32_storage: Vec<Box<[f32]>> = Vec::new();
+    let mut f64_storage: Vec<Box<[f64]>> = Vec::new();
+
+    for col_idx in 0..num_cols {
+        let field = schema.field(col_idx);
+        let col = batch.column(col_idx);
+        let validity = col.nulls().map(|nulls| nulls.validity());
+
+        js_names.set(col_idx as u32, JsString::from(field.name().as_str()).into());
+
+        match col.data_type() {
+            DataType::UInt32 => {
+                let vals = col.as_primitive::<UInt32Type>().values();
+                let arr = unsafe { js_sys::Uint32Array::view(vals.as_ref()) };
+                js_values.set(col_idx as u32, arr.into());
+                js_dicts.set(col_idx as u32, JsValue::NULL);
+            },
+            DataType::Int32 => {
+                let vals = col.as_primitive::<Int32Type>().values();
+                let arr = unsafe { js_sys::Int32Array::view(vals.as_ref()) };
+                js_values.set(col_idx as u32, arr.into());
+                js_dicts.set(col_idx as u32, JsValue::NULL);
+            },
+            DataType::Float32 => {
+                let vals = col.as_primitive::<Float32Type>().values();
+                let arr = unsafe { js_sys::Float32Array::view(vals.as_ref()) };
+                js_values.set(col_idx as u32, arr.into());
+                js_dicts.set(col_idx as u32, JsValue::NULL);
+            },
+            DataType::Float64 => {
+                if float32 {
+                    let vals = col.as_primitive::<Float64Type>().values();
+                    f32_storage.push(vals.iter().map(|&v| v as f32).collect());
+                } else {
+                    let vals = col.as_primitive::<Float64Type>().values();
+                    let arr = unsafe { js_sys::Float64Array::view(vals.as_ref()) };
+                    js_values.set(col_idx as u32, arr.into());
+                }
+                js_dicts.set(col_idx as u32, JsValue::NULL);
+            },
+            DataType::Date32 => {
+                let typed = col.as_primitive::<Date32Type>();
+                if float32 {
+                    f32_storage.push(
+                        typed
+                            .values()
+                            .iter()
+                            .map(|&v| v as f32 * 86_400_000.0)
+                            .collect(),
+                    );
+                } else {
+                    f64_storage.push(
+                        typed
+                            .values()
+                            .iter()
+                            .map(|&v| v as f64 * 86_400_000.0)
+                            .collect(),
+                    );
+                }
+                js_dicts.set(col_idx as u32, JsValue::NULL);
+            },
+            DataType::Timestamp(TimeUnit::Millisecond, _) => {
+                let typed = col.as_primitive::<TimestampMillisecondType>();
+                if float32 {
+                    f32_storage.push(typed.values().iter().map(|&v| v as f32).collect());
+                } else {
+                    f64_storage.push(typed.values().iter().map(|&v| v as f64).collect());
+                }
+                js_dicts.set(col_idx as u32, JsValue::NULL);
+            },
+            DataType::Int64 => {
+                let typed = col.as_primitive::<Int64Type>();
+                if float32 {
+                    f32_storage.push(typed.values().iter().map(|&v| v as f32).collect());
+                } else {
+                    f64_storage.push(typed.values().iter().map(|&v| v as f64).collect());
+                }
+                js_dicts.set(col_idx as u32, JsValue::NULL);
+            },
+            DataType::Dictionary(..) => {
+                let dict = col.as_dictionary::<Int32Type>();
+                let keys = dict.keys();
+                let arr = unsafe { js_sys::Int32Array::view(keys.values().as_ref()) };
+                js_values.set(col_idx as u32, arr.into());
+
+                let values = dict.values().as_string::<i32>();
+                let js_dict = Array::new_with_length(values.len() as u32);
+                for i in 0..values.len() {
+                    js_dict.set(i as u32, JsValue::from_str(values.value(i)));
+                }
+                js_dicts.set(col_idx as u32, js_dict.into());
+            },
+            dt => {
+                return Err(JsValue::from_str(&format!(
+                    "Unsupported column type for typed array: {dt}"
+                )));
+            },
+        }
+
+        // SAFETY: Validity bitmap is owned by `batch` which outlives the
+        // callback — safe to view zero-copy.
+        let js_validity = validity.map(|v| unsafe { Uint8Array::view(v) });
+        js_validities.set(
+            col_idx as u32,
+            js_validity
+                .as_ref()
+                .map(JsValue::from)
+                .unwrap_or(JsValue::NULL),
+        );
+    }
+
+    // Second pass: fill in value views for columns backed by f32_storage /
+    // f64_storage. The Box<[T]> buffers are heap-allocated and stable; their
+    // data pointers remain valid even as the outer Vec grows.
+    let mut f32_idx = 0;
+    let mut f64_idx = 0;
+    for col_idx in 0..num_cols {
+        let col = batch.column(col_idx);
+        let uses_f32_storage = matches!(
+            (col.data_type(), float32),
+            (DataType::Float64, true)
+                | (DataType::Date32, true)
+                | (DataType::Timestamp(TimeUnit::Millisecond, _), true)
+                | (DataType::Int64, true),
+        );
+        let uses_f64_storage = matches!(
+            (col.data_type(), float32),
+            (DataType::Date32, false)
+                | (DataType::Timestamp(TimeUnit::Millisecond, _), false)
+                | (DataType::Int64, false),
+        );
+
+        if uses_f32_storage {
+            let arr = unsafe { js_sys::Float32Array::view(&f32_storage[f32_idx]) };
+            js_values.set(col_idx as u32, arr.into());
+            f32_idx += 1;
+        } else if uses_f64_storage {
+            let arr = unsafe { js_sys::Float64Array::view(&f64_storage[f64_idx]) };
+            js_values.set(col_idx as u32, arr.into());
+            f64_idx += 1;
+        }
+    }
+
+    callback.call4(
+        &JsValue::UNDEFINED,
+        &js_names.into(),
+        &js_values.into(),
+        &js_validities.into(),
+        &js_dicts.into(),
+    )?;
+
+    // Keep storage alive until after the callback returns.
+    drop(f32_storage);
+    drop(f64_storage);
+
+    Ok(())
+}

--- a/rust/perspective-js/src/rust/view.rs
+++ b/rust/perspective-js/src/rust/view.rs
@@ -247,6 +247,35 @@ impl View {
         Ok(self.0.to_csv(window.unwrap_or_default()).await?)
     }
 
+    /// Fetches columns from the [`View`] in Arrow format, decodes them, and
+    /// passes typed array views to `callback`. All arrays are only valid for
+    /// the duration of the callback.
+    ///
+    /// # Arguments
+    ///
+    /// - `window` - Optional [`TypedArrayWindow`] controlling row/column
+    ///   windowing and output options (e.g., `float32` mode).
+    /// - `callback` - A JS function called with `(names: string[], values:
+    ///   TypedArray[], validities: (Uint8Array|null)[], dictionaries:
+    ///   (string[]|null)[])`.
+    #[wasm_bindgen]
+    pub async fn with_typed_arrays(
+        &self,
+        window: Option<crate::typed_array::JsTypedArrayWindow>,
+        callback: Function,
+    ) -> ApiResult<()> {
+        let opts: crate::typed_array::TypedArrayWindow = window
+            .into_serde_ext::<Option<crate::typed_array::TypedArrayWindow>>()?
+            .unwrap_or_default();
+
+        let float32 = opts.float32;
+        let mut view_window: ViewWindow = opts.into();
+        view_window.emit_legacy_row_path_names = Some(false);
+        let arrow = self.0.to_arrow(view_window).await?;
+        crate::typed_array::decode_and_call(&arrow, float32, &callback)?;
+        Ok(())
+    }
+
     /// Register a callback with this [`View`]. Whenever the view's underlying
     /// table emits an update, this callback will be invoked with an object
     /// containing `port_id`, indicating which port the update fired on, and

--- a/rust/perspective-js/src/ts/wasm/engine.ts
+++ b/rust/perspective-js/src/ts/wasm/engine.ts
@@ -234,8 +234,8 @@ async function decode_api_responses(
                       messages.getInt32(i * 16 + 12, true),
                   ]
                 : [
-                      messages.getInt32(i * 12, true),
-                      messages.getInt32(i * 12 + 4, true),
+                      messages.getUint32(i * 12, true),
+                      messages.getUint32(i * 12 + 4, true),
                       messages.getInt32(i * 12 + 8, true),
                   ];
 

--- a/rust/perspective-js/test/js/to_format/with_column_typed_array.spec.ts
+++ b/rust/perspective-js/test/js/to_format/with_column_typed_array.spec.ts
@@ -1,0 +1,776 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { test, expect } from "@perspective-dev/test";
+import perspective from "../perspective_client";
+
+test.describe("with_typed_arrays()", () => {
+    test("returns all columns with names, values, validities, dictionaries", async () => {
+        const table = await perspective.table({
+            a: [1, 2, 3],
+            b: [10.0, 20.0, 30.0],
+        });
+
+        const view = await table.view();
+        let names: string[] = [];
+        let valuesMap: Record<string, ArrayLike<number>> = {};
+        await view.with_typed_arrays(
+            {},
+            (
+                n: string[],
+                vals: ArrayLike<number>[],
+                _valids: (Uint8Array | null)[],
+                _dicts: (string[] | null)[],
+            ) => {
+                names = Array.from(n);
+                for (let i = 0; i < names.length; i++) {
+                    valuesMap[names[i]] = vals[i];
+                }
+            },
+        );
+
+        expect(names).toContain("a");
+        expect(names).toContain("b");
+        expect(Array.from(valuesMap["b"])).toEqual([10.0, 20.0, 30.0]);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("returns Float64Array for float column by default", async () => {
+        const table = await perspective.table({ x: [1.5, 2.5, 3.5] });
+        const view = await table.view();
+        let result: Float64Array | null = null;
+        await view.with_typed_arrays(
+            {},
+            (_n: string[], vals: ArrayLike<number>[]) => {
+                result = new Float64Array(vals[0] as Float64Array);
+            },
+        );
+
+        expect(Array.from(result!)).toEqual([1.5, 2.5, 3.5]);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("returns Float32Array when float32 option is set", async () => {
+        const table = await perspective.table({ x: [1.5, 2.5, 3.5] });
+        const view = await table.view();
+        let isFloat32 = false;
+        await view.with_typed_arrays(
+            { float32: true },
+            (_n: string[], vals: any[]) => {
+                isFloat32 = vals[0] instanceof Float32Array;
+            },
+        );
+
+        expect(isFloat32).toBe(true);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("returns Int32Array for integer column", async () => {
+        const table = await perspective.table({ x: "integer" });
+        table.update({ x: [10, 20, 30] });
+        const view = await table.view();
+        let result: Int32Array | null = null;
+        await view.with_typed_arrays(
+            {},
+            (_n: string[], vals: ArrayLike<number>[]) => {
+                result = new Int32Array(vals[0] as Int32Array);
+            },
+        );
+
+        expect(Array.from(result!)).toEqual([10, 20, 30]);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("passes validity bitmap for columns with nulls", async () => {
+        const table = await perspective.table({ x: [1.5, null, 3.5, null] });
+        const view = await table.view();
+        let validity: Uint8Array | null = null;
+        await view.with_typed_arrays(
+            {},
+            (_n: string[], _vals: any[], valids: (Uint8Array | null)[]) => {
+                validity = valids[0] ? new Uint8Array(valids[0]) : null;
+            },
+        );
+
+        // Bits 0 and 2 set => 0b0101 = 5
+        expect(validity![0]).toEqual(0b0101);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("validity is null when no nulls present", async () => {
+        const table = await perspective.table({ x: [1.0, 2.0, 3.0] });
+        const view = await table.view();
+        let validityWasNull = false;
+        await view.with_typed_arrays(
+            {},
+            (_n: string[], _vals: any[], valids: (Uint8Array | null)[]) => {
+                validityWasNull = valids[0] === null;
+            },
+        );
+
+        expect(validityWasNull).toBe(true);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("returns dictionary keys and values for string column", async () => {
+        const table = await perspective.table({
+            x: ["apple", "banana", "apple", "cherry"],
+        });
+        const view = await table.view();
+        let keys: Int32Array | null = null;
+        let dict: string[] | null = null;
+        await view.with_typed_arrays(
+            {},
+            (
+                _n: string[],
+                vals: ArrayLike<number>[],
+                _valids: any[],
+                dicts: (string[] | null)[],
+            ) => {
+                keys = new Int32Array(vals[0] as Int32Array);
+                dict = dicts[0] ? Array.from(dicts[0]) : null;
+            },
+        );
+
+        expect(keys!.length).toEqual(4);
+        const resolved = Array.from(keys!).map((k) => dict![k]);
+        expect(resolved).toEqual(["apple", "banana", "apple", "cherry"]);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("dictionary is null for non-string columns", async () => {
+        const table = await perspective.table({ x: [1.0, 2.0, 3.0] });
+        const view = await table.view();
+        let dictWasNull = false;
+        await view.with_typed_arrays(
+            {},
+            (
+                _n: string[],
+                _vals: any[],
+                _valids: any[],
+                dicts: (string[] | null)[],
+            ) => {
+                dictWasNull = dicts[0] === null;
+            },
+        );
+
+        expect(dictWasNull).toBe(true);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("supports row windowing via start_row/end_row", async () => {
+        const table = await perspective.table({ x: [10, 20, 30, 40, 50] });
+        const view = await table.view();
+        let result: Int32Array | null = null;
+        await view.with_typed_arrays(
+            { start_row: 1, end_row: 3 },
+            (_n: string[], vals: ArrayLike<number>[]) => {
+                result = new Int32Array(vals[0] as Int32Array);
+            },
+        );
+
+        expect(Array.from(result!)).toEqual([20, 30]);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("returns Float64Array of millis for datetime column", async () => {
+        const d1 = new Date("2020-01-01T00:00:00Z");
+        const d2 = new Date("2021-06-15T12:30:00Z");
+        const table = await perspective.table({
+            x: [d1.getTime(), d2.getTime()],
+        });
+        const view = await table.view();
+        let result: Float64Array | null = null;
+        await view.with_typed_arrays(
+            {},
+            (_n: string[], vals: ArrayLike<number>[]) => {
+                result = new Float64Array(vals[0] as Float64Array);
+            },
+        );
+
+        expect(Array.from(result!)).toEqual([d1.getTime(), d2.getTime()]);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("returns Float64Array of millis for date column", async () => {
+        const table = await perspective.table({ x: "date" });
+        table.update({ x: ["2020-01-01", "2021-06-15"] });
+        const view = await table.view();
+        let result: Float64Array | null = null;
+        await view.with_typed_arrays(
+            {},
+            (_n: string[], vals: ArrayLike<number>[]) => {
+                result = new Float64Array(vals[0] as Float64Array);
+            },
+        );
+
+        const expected = [
+            new Date("2020-01-01").getTime(),
+            new Date("2021-06-15").getTime(),
+        ];
+        expect(Array.from(result!)).toEqual(expected);
+        await view.delete();
+        await table.delete();
+    });
+
+    test.describe("float32 option", () => {
+        test("Float64 column contents narrowed to Float32Array", async () => {
+            const table = await perspective.table({ x: [1.5, 2.5, 3.5, 4.5] });
+            const view = await table.view();
+            let result: Float32Array | null = null;
+            await view.with_typed_arrays(
+                { float32: true },
+                (_n: string[], vals: any[]) => {
+                    result = new Float32Array(vals[0]);
+                },
+            );
+
+            expect(result).toBeInstanceOf(Float32Array);
+            // Values exactly representable in float32
+            expect(Array.from(result!)).toEqual([1.5, 2.5, 3.5, 4.5]);
+            await view.delete();
+            await table.delete();
+        });
+
+        test("Int32 column is NOT affected by float32 option", async () => {
+            const table = await perspective.table({ x: "integer" });
+            table.update({ x: [10, 20, 30] });
+            const view = await table.view();
+            let isInt32 = false;
+            let result: Int32Array | null = null;
+            await view.with_typed_arrays(
+                { float32: true },
+                (_n: string[], vals: any[]) => {
+                    isInt32 = vals[0] instanceof Int32Array;
+                    result = new Int32Array(vals[0]);
+                },
+            );
+
+            expect(isInt32).toBe(true);
+            expect(Array.from(result!)).toEqual([10, 20, 30]);
+            await view.delete();
+            await table.delete();
+        });
+
+        test("Date column narrowed to Float32Array of millis", async () => {
+            const table = await perspective.table({ x: "date" });
+            table.update({ x: ["2020-01-01", "2021-06-15"] });
+            const view = await table.view();
+            let result: Float32Array | null = null;
+            await view.with_typed_arrays(
+                { float32: true },
+                (_n: string[], vals: any[]) => {
+                    result = new Float32Array(vals[0]);
+                },
+            );
+
+            expect(result).toBeInstanceOf(Float32Array);
+            // Float32 precision loss is expected for large millis values
+            const expected = [
+                new Date("2020-01-01").getTime(),
+                new Date("2021-06-15").getTime(),
+            ];
+            // Narrow to f32 then back to compare (lossy conversion)
+            const expectedF32 = Array.from(new Float32Array(expected));
+            expect(Array.from(result!)).toEqual(expectedF32);
+            await view.delete();
+            await table.delete();
+        });
+
+        test("Datetime column narrowed to Float32Array of millis", async () => {
+            const d1 = new Date("2020-01-01T00:00:00Z");
+            const d2 = new Date("2021-06-15T12:30:00Z");
+            const table = await perspective.table({
+                x: [d1.getTime(), d2.getTime()],
+            });
+            const view = await table.view();
+            let result: Float32Array | null = null;
+            await view.with_typed_arrays(
+                { float32: true },
+                (_n: string[], vals: any[]) => {
+                    result = new Float32Array(vals[0]);
+                },
+            );
+
+            expect(result).toBeInstanceOf(Float32Array);
+            const expectedF32 = Array.from(
+                new Float32Array([d1.getTime(), d2.getTime()]),
+            );
+            expect(Array.from(result!)).toEqual(expectedF32);
+            await view.delete();
+            await table.delete();
+        });
+
+        test("Dictionary string column returns Int32Array keys (unaffected by float32)", async () => {
+            const table = await perspective.table({
+                x: ["a", "b", "a", "c"],
+            });
+            const view = await table.view();
+            let isInt32 = false;
+            let dict: string[] | null = null;
+            await view.with_typed_arrays(
+                { float32: true },
+                (
+                    _n: string[],
+                    vals: any[],
+                    _valids: any[],
+                    dicts: (string[] | null)[],
+                ) => {
+                    isInt32 = vals[0] instanceof Int32Array;
+                    dict = dicts[0] ? Array.from(dicts[0]) : null;
+                },
+            );
+
+            expect(isInt32).toBe(true);
+            expect(dict).not.toBeNull();
+            await view.delete();
+            await table.delete();
+        });
+
+        test("float32 omitted defaults to Float64Array", async () => {
+            const table = await perspective.table({ x: [1.5, 2.5, 3.5] });
+            const view = await table.view();
+            let isFloat64 = false;
+            await view.with_typed_arrays({}, (_n: string[], vals: any[]) => {
+                isFloat64 = vals[0] instanceof Float64Array;
+            });
+
+            expect(isFloat64).toBe(true);
+            await view.delete();
+            await table.delete();
+        });
+
+        test("float32: false is equivalent to omitting it", async () => {
+            const table = await perspective.table({ x: [1.5, 2.5, 3.5] });
+            const view = await table.view();
+            let isFloat64 = false;
+            await view.with_typed_arrays(
+                { float32: false },
+                (_n: string[], vals: any[]) => {
+                    isFloat64 = vals[0] instanceof Float64Array;
+                },
+            );
+
+            expect(isFloat64).toBe(true);
+            await view.delete();
+            await table.delete();
+        });
+
+        test("float32 combines with row windowing", async () => {
+            const table = await perspective.table({
+                x: [1.5, 2.5, 3.5, 4.5, 5.5],
+            });
+            const view = await table.view();
+            let result: Float32Array | null = null;
+            await view.with_typed_arrays(
+                { float32: true, start_row: 1, end_row: 4 },
+                (_n: string[], vals: any[]) => {
+                    result = new Float32Array(vals[0]);
+                },
+            );
+
+            expect(result).toBeInstanceOf(Float32Array);
+            expect(Array.from(result!)).toEqual([2.5, 3.5, 4.5]);
+            await view.delete();
+            await table.delete();
+        });
+
+        test("float32 on multi-column view: floats narrowed, ints unchanged", async () => {
+            const table = await perspective.table({
+                a: "integer",
+                b: "float",
+            });
+            table.update({ a: [1, 2, 3], b: [1.5, 2.5, 3.5] });
+            const view = await table.view();
+            const typeMap: Record<string, string> = {};
+            await view.with_typed_arrays(
+                { float32: true },
+                (n: string[], vals: any[]) => {
+                    for (let i = 0; i < n.length; i++) {
+                        typeMap[n[i]] = vals[i].constructor.name;
+                    }
+                },
+            );
+
+            expect(typeMap["a"]).toEqual("Int32Array");
+            expect(typeMap["b"]).toEqual("Float32Array");
+            await view.delete();
+            await table.delete();
+        });
+    });
+
+    test.describe("group_by", () => {
+        test("emits __ROW_PATH_0__ column for single group_by", async () => {
+            const table = await perspective.table({
+                category: ["a", "a", "b", "b"],
+                value: [1, 2, 3, 4],
+            });
+            const view = await table.view({
+                group_by: ["category"],
+                aggregates: { value: "sum" },
+            });
+
+            let names: string[] = [];
+            await view.with_typed_arrays({}, (n: string[]) => {
+                names = Array.from(n);
+            });
+
+            expect(names).toContain("__ROW_PATH_0__");
+            // Should NOT contain the legacy "category (Group by 1)" naming
+            expect(names).not.toContain("category (Group by 1)");
+            await view.delete();
+            await table.delete();
+        });
+
+        test("__ROW_PATH_0__ is a Dictionary column with expected values", async () => {
+            const table = await perspective.table({
+                category: ["a", "a", "b", "b", "c"],
+                value: [1, 2, 3, 4, 5],
+            });
+            const view = await table.view({
+                group_by: ["category"],
+                aggregates: { value: "sum" },
+            });
+
+            let keys: Int32Array | null = null;
+            let dict: string[] | null = null;
+            await view.with_typed_arrays(
+                {},
+                (
+                    n: string[],
+                    vals: any[],
+                    _valids: any[],
+                    dicts: (string[] | null)[],
+                ) => {
+                    const idx = n.indexOf("__ROW_PATH_0__");
+                    expect(idx).toBeGreaterThanOrEqual(0);
+                    keys = new Int32Array(vals[idx]);
+                    dict = dicts[idx] ? Array.from(dicts[idx]) : null;
+                },
+            );
+
+            expect(dict).not.toBeNull();
+            // Resolve keys to strings. First row is the total (empty/null),
+            // remaining rows are the groups.
+            const resolved = Array.from(keys!).map((k) =>
+                k >= 0 ? dict![k] : null,
+            );
+            expect(resolved.slice(1).sort()).toEqual(["a", "b", "c"]);
+            await view.delete();
+            await table.delete();
+        });
+
+        test("emits __ROW_PATH_0__ and __ROW_PATH_1__ for two-level group_by", async () => {
+            const table = await perspective.table({
+                region: ["US", "US", "EU", "EU"],
+                country: ["x", "y", "a", "b"],
+                value: [1, 2, 3, 4],
+            });
+            const view = await table.view({
+                group_by: ["region", "country"],
+                aggregates: { value: "sum" },
+            });
+
+            let names: string[] = [];
+            await view.with_typed_arrays({}, (n: string[]) => {
+                names = Array.from(n);
+            });
+
+            expect(names).toContain("__ROW_PATH_0__");
+            expect(names).toContain("__ROW_PATH_1__");
+            expect(names).not.toContain("region (Group by 1)");
+            expect(names).not.toContain("country (Group by 2)");
+            await view.delete();
+            await table.delete();
+        });
+
+        test("aggregate value column is present alongside row path", async () => {
+            const table = await perspective.table({
+                category: ["a", "a", "b"],
+                value: [10, 20, 30],
+            });
+            const view = await table.view({
+                group_by: ["category"],
+                aggregates: { value: "sum" },
+            });
+
+            const columns: Record<string, any> = {};
+            await view.with_typed_arrays(
+                {},
+                (
+                    n: string[],
+                    vals: any[],
+                    _valids: any[],
+                    dicts: (string[] | null)[],
+                ) => {
+                    for (let i = 0; i < n.length; i++) {
+                        columns[n[i]] = { vals: vals[i], dict: dicts[i] };
+                    }
+                },
+            );
+
+            expect(columns["__ROW_PATH_0__"]).toBeDefined();
+            expect(columns["value"]).toBeDefined();
+            // Value column should be numeric (not Dictionary)
+            expect(columns["value"].dict).toBeNull();
+            await view.delete();
+            await table.delete();
+        });
+
+        test("regular to_arrow still uses legacy naming by default", async () => {
+            // Sanity check: `to_arrow` (not with_typed_arrays) should
+            // still use legacy "colname (Group by N)" naming for backwards
+            // compatibility. `with_typed_arrays` forces the new naming.
+            const table = await perspective.table({
+                category: ["a", "b"],
+                value: [1, 2],
+            });
+            const view = await table.view({
+                group_by: ["category"],
+                aggregates: { value: "sum" },
+            });
+
+            const arrow = await view.to_arrow();
+            // The Arrow IPC bytes should contain the legacy name.
+            const bytes = new Uint8Array(arrow);
+            const text = new TextDecoder().decode(bytes);
+            expect(text.includes("(Group by 1)")).toBe(true);
+            await view.delete();
+            await table.delete();
+        });
+    });
+
+    test.describe("group_rollup_mode: flat", () => {
+        test("emits one row per distinct group (no total/aggregate rows)", async () => {
+            // In flat mode, only leaf rows are emitted — no intermediate
+            // rollup totals. 5 input rows with 3 distinct categories yields
+            // 3 output rows (one per group).
+            const table = await perspective.table({
+                category: ["a", "a", "b", "b", "c"],
+                value: [1, 2, 3, 4, 5],
+            });
+            const view = await table.view({
+                group_by: ["category"],
+                group_rollup_mode: "flat",
+                aggregates: { value: "sum" },
+            });
+
+            let rowCount = 0;
+            await view.with_typed_arrays({}, (_n: string[], vals: any[]) => {
+                rowCount = vals[0].length;
+            });
+
+            expect(rowCount).toEqual(3);
+            await view.delete();
+            await table.delete();
+        });
+
+        test("__ROW_PATH_0__ contains one entry per distinct group", async () => {
+            const table = await perspective.table({
+                category: ["a", "b", "a", "c"],
+                value: [10, 20, 30, 40],
+            });
+            const view = await table.view({
+                group_by: ["category"],
+                group_rollup_mode: "flat",
+                aggregates: { value: "sum" },
+            });
+
+            let paths: (string | null)[] = [];
+            await view.with_typed_arrays(
+                {},
+                (
+                    n: string[],
+                    vals: any[],
+                    _valids: any[],
+                    dicts: (string[] | null)[],
+                ) => {
+                    const idx = n.indexOf("__ROW_PATH_0__");
+                    const keys = vals[idx] as Int32Array;
+                    const dict = dicts[idx]!;
+                    paths = Array.from(keys).map((k) =>
+                        k >= 0 ? dict[k] : null,
+                    );
+                },
+            );
+
+            expect(paths.slice().sort()).toEqual(["a", "b", "c"]);
+            await view.delete();
+            await table.delete();
+        });
+
+        test("aggregate column contains per-group sums in flat mode", async () => {
+            // Sum aggregate per group: a=10+20=30, b=30.
+            const table = await perspective.table({
+                category: ["a", "a", "b"],
+                value: [10, 20, 30],
+            });
+            const view = await table.view({
+                group_by: ["category"],
+                group_rollup_mode: "flat",
+                aggregates: { value: "sum" },
+            });
+
+            const rowMap: Record<string, number> = {};
+            await view.with_typed_arrays(
+                {},
+                (
+                    n: string[],
+                    vals: any[],
+                    _valids: any[],
+                    dicts: (string[] | null)[],
+                ) => {
+                    const pathIdx = n.indexOf("__ROW_PATH_0__");
+                    const valueIdx = n.indexOf("value");
+                    const keys = vals[pathIdx] as Int32Array;
+                    const dict = dicts[pathIdx]!;
+                    const values = vals[valueIdx] as ArrayLike<number>;
+                    for (let i = 0; i < keys.length; i++) {
+                        rowMap[dict[keys[i]]] = values[i];
+                    }
+                },
+            );
+
+            expect(rowMap).toEqual({ a: 30, b: 30 });
+            await view.delete();
+            await table.delete();
+        });
+
+        test("flat mode with two-level group_by emits both __ROW_PATH_N__ columns", async () => {
+            const table = await perspective.table({
+                region: ["US", "US", "EU"],
+                country: ["x", "y", "a"],
+                value: [1, 2, 3],
+            });
+            const view = await table.view({
+                group_by: ["region", "country"],
+                group_rollup_mode: "flat",
+                aggregates: { value: "sum" },
+            });
+
+            let names: string[] = [];
+            const paths: Record<string, (string | null)[]> = {};
+            await view.with_typed_arrays(
+                {},
+                (
+                    n: string[],
+                    vals: any[],
+                    _valids: any[],
+                    dicts: (string[] | null)[],
+                ) => {
+                    names = Array.from(n);
+                    for (const key of ["__ROW_PATH_0__", "__ROW_PATH_1__"]) {
+                        const idx = n.indexOf(key);
+                        if (idx >= 0) {
+                            const keys = vals[idx] as Int32Array;
+                            const dict = dicts[idx]!;
+                            paths[key] = Array.from(keys).map((k) =>
+                                k >= 0 ? dict[k] : null,
+                            );
+                        }
+                    }
+                },
+            );
+
+            expect(names).toContain("__ROW_PATH_0__");
+            expect(names).toContain("__ROW_PATH_1__");
+            // 3 distinct (region, country) combinations — one row each.
+            expect(paths["__ROW_PATH_0__"].length).toEqual(3);
+            expect(paths["__ROW_PATH_1__"].length).toEqual(3);
+            // Ensure (region, country) pairs are preserved.
+            const pairs = paths["__ROW_PATH_0__"].map(
+                (r, i) => `${r}|${paths["__ROW_PATH_1__"][i]}`,
+            );
+            expect(pairs.slice().sort()).toEqual(["EU|a", "US|x", "US|y"]);
+            await view.delete();
+            await table.delete();
+        });
+
+        test("flat mode: all __ROW_PATH_N__ values are non-null (no aggregate rows)", async () => {
+            // In rollup mode, aggregate/total rows have null path segments.
+            // In flat mode, every row is a leaf so all paths are fully
+            // populated.
+            const table = await perspective.table({
+                region: ["US", "EU"],
+                country: ["x", "y"],
+                value: [1, 2],
+            });
+            const view = await table.view({
+                group_by: ["region", "country"],
+                group_rollup_mode: "flat",
+                aggregates: { value: "sum" },
+            });
+
+            let hasNullPath = false;
+            await view.with_typed_arrays(
+                {},
+                (
+                    n: string[],
+                    vals: any[],
+                    _valids: any[],
+                    dicts: (string[] | null)[],
+                ) => {
+                    for (let i = 0; i < n.length; i++) {
+                        if (!n[i].startsWith("__ROW_PATH_")) continue;
+                        const keys = vals[i] as Int32Array;
+                        const dict = dicts[i];
+                        for (let j = 0; j < keys.length; j++) {
+                            if (keys[j] < 0 || !dict || !dict[keys[j]]) {
+                                hasNullPath = true;
+                                return;
+                            }
+                        }
+                    }
+                },
+            );
+
+            expect(hasNullPath).toBe(false);
+            await view.delete();
+            await table.delete();
+        });
+
+        test("flat mode preserves value types (Int64 aggregate not coerced)", async () => {
+            // Flat-mode sum over integer input still flows through as an
+            // Int64 column (from the C++ engine's aggregate type), which
+            // with_typed_arrays converts to Float64Array.
+            const table = await perspective.table({
+                category: ["a", "b", "c"],
+                value: [10, 20, 30],
+            });
+            const view = await table.view({
+                group_by: ["category"],
+                group_rollup_mode: "flat",
+                aggregates: { value: "sum" },
+            });
+
+            let valueType = "";
+            await view.with_typed_arrays({}, (n: string[], vals: any[]) => {
+                const idx = n.indexOf("value");
+                valueType = vals[idx].constructor.name;
+            });
+
+            expect(valueType).toEqual("Float64Array");
+            await view.delete();
+            await table.delete();
+        });
+    });
+});

--- a/rust/perspective-python/src/server/generic_sql_model.rs
+++ b/rust/perspective-python/src/server/generic_sql_model.rs
@@ -178,6 +178,7 @@ impl From<PyViewPort> for ViewPort {
             start_col: value.start_col,
             end_row: value.end_row,
             end_col: value.end_col,
+            emit_legacy_row_path_names: None,
         }
     }
 }

--- a/rust/perspective-server/build.rs
+++ b/rust/perspective-server/build.rs
@@ -111,9 +111,10 @@ fn cmake_build() -> Result<Option<PathBuf>, std::io::Error> {
         dst.define("PSP_WASM_EXCEPTIONS", "0");
     }
 
-    if !cfg!(windows) {
-        dst.build_arg(format!("-j{}", num_cpus::get()));
-    }
+    // Propagates to nested `cmake --build` invocations (e.g. the per-dep
+    // fetch builds in FindInstallDependency.cmake), unlike `-j` via `build_arg`
+    // which only reaches the top-level native tool.
+    dst.env("CMAKE_BUILD_PARALLEL_LEVEL", num_cpus::get().to_string());
 
     // Conda sets CMAKE_ARGS for e.g. cross-compiling toolchain in the environment -
     // normally they are passed directly to a cmake invocation in the recipe,

--- a/rust/perspective-server/cpp/perspective/src/cpp/context_grouped_pkey.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/context_grouped_pkey.cpp
@@ -676,7 +676,9 @@ t_ctx_grouped_pkey::pprint() const {
 }
 
 void
-t_ctx_grouped_pkey::notify(const t_data_table& flattened) {
+t_ctx_grouped_pkey::notify(
+    const t_data_table& flattened, bool /* is_registration */
+) {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
 

--- a/rust/perspective-server/cpp/perspective/src/cpp/context_one.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/context_one.cpp
@@ -276,7 +276,7 @@ t_ctx1::get_data(const std::vector<t_uindex>& rows) const {
 }
 
 void
-t_ctx1::notify(const t_data_table& flattened) {
+t_ctx1::notify(const t_data_table& flattened, bool /* is_registration */) {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
 

--- a/rust/perspective-server/cpp/perspective/src/cpp/context_two.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/context_two.cpp
@@ -509,7 +509,7 @@ t_ctx2::reset_sortby() {
 }
 
 void
-t_ctx2::notify(const t_data_table& flattened) {
+t_ctx2::notify(const t_data_table& flattened, bool /* is_registration */) {
     for (t_uindex tree_idx = 0, loop_end = m_trees.size(); tree_idx < loop_end;
          ++tree_idx) {
         if (is_rtree_idx(tree_idx) != 0U) {

--- a/rust/perspective-server/cpp/perspective/src/cpp/context_unit.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/context_unit.cpp
@@ -111,13 +111,20 @@ t_ctxunit::notify(
  * @param flattened
  */
 void
-t_ctxunit::notify(const t_data_table& flattened) {
+t_ctxunit::notify(const t_data_table& flattened, bool is_registration) {
     t_uindex nrecs = flattened.size();
     std::shared_ptr<const t_column> pkey_sptr =
         flattened.get_const_column("psp_pkey");
     const t_column* pkey_col = pkey_sptr.get();
 
     m_has_delta = true;
+
+    // During `_register_context`, no subscriber exists yet — skip the
+    // hopscotch_set insertions no observer can see. A unit context has no
+    // traversal/sort state to build either, so this is effectively O(1).
+    if (is_registration) {
+        return;
+    }
 
     // TODO: pkey and idx are equal, except idx is not a t_tscalar. I don't
     // think there is a difference between accessing the pkey column and

--- a/rust/perspective-server/cpp/perspective/src/cpp/context_zero.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/context_zero.cpp
@@ -184,7 +184,7 @@ t_ctx0::notify(
  * @param flattened
  */
 void
-t_ctx0::notify(const t_data_table& flattened) {
+t_ctx0::notify(const t_data_table& flattened, bool is_registration) {
     t_uindex nrecs = flattened.size();
     std::shared_ptr<const t_column> pkey_sptr =
         flattened.get_const_column("psp_pkey");
@@ -194,6 +194,40 @@ t_ctx0::notify(const t_data_table& flattened) {
     const t_column* op_col = op_sptr.get();
 
     m_has_delta = true;
+
+    // During `_register_context`, no subscriber exists yet to observe the
+    // delta set produced here — skip populating `m_delta_pkeys` so we don't
+    // allocate one hopscotch_set entry per row. The first real update goes
+    // through the 6-arg `notify` which tracks deltas normally.
+    const bool track_deltas = !is_registration;
+
+    // Fast path: unsorted, unfiltered, empty traversal (i.e. initial
+    // registration of a pass-through ctx0). Skip the `m_new_elems`
+    // hopscotch_map round-trip and the subsequent `step_end` rebuild of
+    // `m_index`; append pkeys directly into `m_index`, then finalize
+    // (pkey-sort + `m_pkeyidx` population). This matches the row order
+    // the existing `add_row`/`step_end` path produces for an empty sort.
+    const bool can_bulk_load = !m_config.has_filters()
+        && m_traversal->empty_sort_by() && m_traversal->size() == 0;
+    if (can_bulk_load) {
+        m_traversal->bulk_load_reserve(nrecs);
+        if (track_deltas) {
+            m_delta_pkeys.reserve(nrecs);
+        }
+        for (t_uindex idx = 0; idx < nrecs; ++idx) {
+            t_tscalar pkey =
+                m_symtable.get_interned_tscalar(pkey_col->get_scalar(idx));
+            std::uint8_t op_ = *(op_col->get_nth<std::uint8_t>(idx));
+            if (static_cast<t_op>(op_) == OP_INSERT) {
+                m_traversal->bulk_load_append(pkey);
+            }
+            if (track_deltas) {
+                add_delta_pkey(pkey);
+            }
+        }
+        m_traversal->bulk_load_finalize();
+        return;
+    }
 
     if (m_config.has_filters()) {
         t_mask msk = filter_table_for_config(flattened, m_config);
@@ -219,8 +253,9 @@ t_ctx0::notify(const t_data_table& flattened) {
                     break;
             }
 
-            // Add primary key to track row delta
-            add_delta_pkey(pkey);
+            if (track_deltas) {
+                add_delta_pkey(pkey);
+            }
         }
 
         return;
@@ -242,8 +277,9 @@ t_ctx0::notify(const t_data_table& flattened) {
                 break;
         }
 
-        // Add primary key to track row delta
-        add_delta_pkey(pkey);
+        if (track_deltas) {
+            add_delta_pkey(pkey);
+        }
     }
 }
 

--- a/rust/perspective-server/cpp/perspective/src/cpp/flat_traversal.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/flat_traversal.cpp
@@ -17,6 +17,8 @@
 #include <perspective/scalar.h>
 #include <perspective/schema.h>
 
+#include <algorithm>
+
 namespace perspective {
 
 t_ftrav::t_ftrav() : m_step_deletes(0), m_step_inserts(0) {
@@ -279,6 +281,14 @@ t_ftrav::step_begin() {
 
 void
 t_ftrav::step_end() {
+    // Fast path: if no incremental work happened this step, `m_index` and
+    // `m_pkeyidx` are already in their final shape (either unchanged, or
+    // populated directly via `bulk_load_append`). Skip the O(N) rebuild.
+    if (m_step_inserts == 0 && m_step_deletes == 0) {
+        m_new_elems.clear();
+        return;
+    }
+
     // The new number of rows in this traversal
     t_index new_size = m_index->size() + m_step_inserts - m_step_deletes;
 
@@ -445,6 +455,44 @@ t_ftrav::get_from_gstate(
     }
     std::shared_ptr<t_data_table> master_table = gstate.get_table();
     return gstate.get(*master_table, colname, pkey);
+}
+
+void
+t_ftrav::bulk_load_reserve(t_uindex n) {
+    m_index->reserve(n);
+    m_pkeyidx.reserve(n);
+}
+
+void
+t_ftrav::bulk_load_append(t_tscalar pkey) {
+    // Pre-condition: `empty_sort_by()` and the caller has ownership of
+    // step framing (i.e. we're inside a `step_begin`/`step_end` pair for
+    // an initial registration). `m_step_inserts` is intentionally NOT
+    // incremented so that `step_end` takes its short-circuit path.
+    // `m_pkeyidx` is populated in `bulk_load_finalize` after sorting,
+    // not here — the pkey-to-index mapping only has meaning once the
+    // final sort order is determined.
+    m_index->emplace_back();
+    m_index->back().m_pkey = pkey;
+}
+
+void
+t_ftrav::bulk_load_finalize() {
+    // Match the order the existing `add_row`/`step_end` path would
+    // produce for an empty sort spec: `cmp_mselem` with zero sort
+    // columns falls through to `a.m_pkey < b.m_pkey`, so sort
+    // `m_index` by pkey and then rebuild `m_pkeyidx` against the final
+    // row positions.
+    std::sort(
+        m_index->begin(),
+        m_index->end(),
+        [](const t_mselem& a, const t_mselem& b) {
+            return a.m_pkey < b.m_pkey;
+        }
+    );
+    for (t_uindex i = 0, loop_end = m_index->size(); i < loop_end; ++i) {
+        m_pkeyidx[(*m_index)[i].m_pkey] = i;
+    }
 }
 
 } // end namespace perspective

--- a/rust/perspective-server/cpp/perspective/src/cpp/gnode.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/gnode.cpp
@@ -26,6 +26,7 @@
 #include <perspective/parallel_for.h>
 #include <perspective/pyutils.h>
 
+#include <algorithm>
 #include <utility>
 
 namespace perspective {
@@ -316,7 +317,7 @@ t_gnode::_process_table(t_uindex port_id) {
 
     // first update - master table is empty
     if (m_gstate->mapping_size() == 0) {
-        m_gstate->update_master_table(flattened.get());
+        m_gstate->update_master_table(flattened);
         m_oports[PSP_PORT_FLATTENED]->set_table(flattened);
 
         _compute_expressions(flattened);
@@ -582,7 +583,7 @@ t_gnode::_process_table(t_uindex port_id) {
     }
 #endif
 
-    m_gstate->update_master_table(flattened_masked.get());
+    m_gstate->update_master_table(flattened_masked);
 
 #ifdef PSP_GNODE_VERIFY
     {
@@ -721,6 +722,34 @@ t_gnode::send(t_uindex port_id, const t_data_table& fragments) {
     input_port->send(fragments);
 }
 
+void
+t_gnode::init_bulk(const std::shared_ptr<t_data_table>& data_table) {
+    PSP_TRACE_SENTINEL();
+    PSP_VERBOSE_ASSERT(m_init, "Cannot `init_bulk` on an uninited gnode.");
+    PSP_VERBOSE_ASSERT(
+        m_gstate->mapping_size() == 0,
+        "`init_bulk` requires an empty gnode state."
+    );
+    PSP_GIL_UNLOCK();
+    PSP_WRITE_LOCK(*m_lock);
+
+    PSP_GNODE_VERIFY_TABLE(data_table);
+
+    m_was_updated = true;
+
+    m_gstate->init_from_table(data_table);
+
+    PSP_GNODE_VERIFY_TABLE(get_table_sptr());
+
+    // Registered contexts / expressions: on a freshly-constructed `Table`
+    // these collections are empty and the calls are no-ops, but keep them
+    // for parity with `_process_table`'s first-update path so a context
+    // registered between `Table` construction and `init_bulk` is still
+    // notified.
+    _compute_expressions(data_table);
+    _update_contexts_from_state(m_gstate->get_pkeyed_table());
+}
+
 bool
 t_gnode::process(t_uindex port_id) {
     PSP_TRACE_SENTINEL();
@@ -833,7 +862,8 @@ void
 t_gnode::update_context_from_state(
     t_ctxunit* ctx,
     const std::string& name,
-    std::shared_ptr<t_data_table> flattened
+    std::shared_ptr<t_data_table> flattened,
+    bool is_registration
 ) {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
@@ -851,7 +881,7 @@ t_gnode::update_context_from_state(
     const auto& const_flattened = const_cast<const t_data_table&>(*flattened);
 
     ctx->step_begin();
-    ctx->notify(const_flattened);
+    ctx->notify(const_flattened, is_registration);
     ctx->step_end();
 }
 
@@ -881,33 +911,39 @@ t_gnode::_update_contexts_from_state(std::shared_ptr<t_data_table> tbl) {
         const std::string& name = context_names[ctx_idx];
         const t_ctx_handle& ctxh = context_handles[ctx_idx];
 
+        // This is the first-update-to-previously-empty-table path; a client
+        // may have subscribed between context creation and this update and
+        // expects to observe all rows as deltas, so we pass
+        // `is_registration = false`.
         switch (ctxh.get_type()) {
             case TWO_SIDED_CONTEXT: {
                 auto* ctx = static_cast<t_ctx2*>(ctxh.m_ctx);
                 // Do not reset the expression tables on the context,
                 // as they've already been computed.
                 ctx->reset(false);
-                update_context_from_state<t_ctx2>(ctx, name, tbl);
+                update_context_from_state<t_ctx2>(ctx, name, tbl, false);
             } break;
             case ONE_SIDED_CONTEXT: {
                 auto* ctx = static_cast<t_ctx1*>(ctxh.m_ctx);
                 ctx->reset(false);
-                update_context_from_state<t_ctx1>(ctx, name, tbl);
+                update_context_from_state<t_ctx1>(ctx, name, tbl, false);
             } break;
             case ZERO_SIDED_CONTEXT: {
                 auto* ctx = static_cast<t_ctx0*>(ctxh.m_ctx);
                 ctx->reset(false);
-                update_context_from_state<t_ctx0>(ctx, name, tbl);
+                update_context_from_state<t_ctx0>(ctx, name, tbl, false);
             } break;
             case UNIT_CONTEXT: {
                 auto* ctx = static_cast<t_ctxunit*>(ctxh.m_ctx);
                 ctx->reset();
-                update_context_from_state<t_ctxunit>(ctx, name, tbl);
+                update_context_from_state<t_ctxunit>(ctx, name, tbl, false);
             } break;
             case GROUPED_PKEY_CONTEXT: {
                 auto* ctx = static_cast<t_ctx_grouped_pkey*>(ctxh.m_ctx);
                 ctx->reset(false);
-                update_context_from_state<t_ctx_grouped_pkey>(ctx, name, tbl);
+                update_context_from_state<t_ctx_grouped_pkey>(
+                    ctx, name, tbl, false
+                );
             } break;
             default: {
                 PSP_COMPLAIN_AND_ABORT("Unexpected context type");
@@ -1001,6 +1037,42 @@ t_gnode::get_registered_contexts() const {
     return rval;
 }
 
+namespace {
+
+// Build a `t_schema` containing only `psp_pkey`, `psp_op`, and any columns
+// from `extra_cols` that exist in `input_schema`. Used to narrow the schema
+// passed to `t_gstate::get_pkeyed_table()` so that when rows have been
+// deleted (triggering the mask-and-clone branch), only columns the target
+// context actually reads from the flattened table are cloned — rather than
+// every column in the master table.
+t_schema
+make_minimal_pkeyed_schema(
+    const t_schema& input_schema,
+    const std::vector<std::string>& extra_cols
+) {
+    std::vector<std::string> cols{"psp_pkey", "psp_op"};
+    std::vector<t_dtype> types{
+        input_schema.get_dtype("psp_pkey"),
+        input_schema.get_dtype("psp_op")
+    };
+    for (const std::string& colname : extra_cols) {
+        if (colname == "psp_pkey" || colname == "psp_op") {
+            continue;
+        }
+        if (!input_schema.has_column(colname)) {
+            continue;
+        }
+        if (std::find(cols.begin(), cols.end(), colname) != cols.end()) {
+            continue;
+        }
+        cols.push_back(colname);
+        types.push_back(input_schema.get_dtype(colname));
+    }
+    return {cols, types};
+}
+
+} // anonymous namespace
+
 void
 t_gnode::_register_context(
     const std::string& name, t_ctx_type type, std::uintptr_t ptr
@@ -1012,11 +1084,6 @@ t_gnode::_register_context(
     m_contexts[name] = ch;
 
     bool should_update = m_gstate->mapping_size() > 0;
-    std::shared_ptr<t_data_table> pkeyed_table;
-
-    if (should_update) {
-        pkeyed_table = m_gstate->get_pkeyed_table();
-    }
 
     t_expression_vocab& expression_vocab = *(m_expression_vocab);
     t_regex_mapping& expression_regex_mapping = *(m_expression_regex_mapping);
@@ -1041,7 +1108,9 @@ t_gnode::_register_context(
                     )
                 );
 
-                update_context_from_state<t_ctx2>(ctx, name, pkeyed_table);
+                update_context_from_state<t_ctx2>(
+                    ctx, name, m_gstate->get_pkeyed_table(), true
+                );
             }
         } break;
         case ONE_SIDED_CONTEXT: {
@@ -1062,7 +1131,9 @@ t_gnode::_register_context(
                     )
                 );
 
-                update_context_from_state<t_ctx1>(ctx, name, pkeyed_table);
+                update_context_from_state<t_ctx1>(
+                    ctx, name, m_gstate->get_pkeyed_table(), true
+                );
             }
         } break;
         case ZERO_SIDED_CONTEXT: {
@@ -1083,7 +1154,33 @@ t_gnode::_register_context(
                     )
                 );
 
-                update_context_from_state<t_ctx0>(ctx, name, pkeyed_table);
+                // `t_ctx0::notify` only reads `psp_pkey`, `psp_op`, and
+                // non-expression filter columns from the flattened table.
+                // Expression filter columns are supplied by the expression
+                // table that `update_context_from_state` joins in.
+                const t_config& config = ctx->get_config();
+                const t_schema& expr_schema =
+                    ctx->get_expression_tables()->m_master->get_schema();
+                std::vector<std::string> extra_cols;
+                if (config.has_filters()) {
+                    for (const t_fterm& fterm : config.get_fterms()) {
+                        if (expr_schema.has_column(fterm.m_colname)) {
+                            continue;
+                        }
+                        extra_cols.push_back(fterm.m_colname);
+                    }
+                }
+                t_schema narrow_schema = make_minimal_pkeyed_schema(
+                    m_gstate->get_input_schema(), extra_cols
+                );
+                update_context_from_state<t_ctx0>(
+                    ctx,
+                    name,
+                    m_gstate->get_pkeyed_table(
+                        narrow_schema, m_gstate->get_table()
+                    ),
+                    true
+                );
             }
         } break;
         case UNIT_CONTEXT: {
@@ -1093,7 +1190,20 @@ t_gnode::_register_context(
 
             // No expressions here to deal with
             if (should_update) {
-                update_context_from_state<t_ctxunit>(ctx, name, pkeyed_table);
+                // `t_ctxunit::notify` only reads `psp_pkey` from the
+                // flattened table, so narrow the pkeyed table to the
+                // identifying columns only.
+                t_schema narrow_schema = make_minimal_pkeyed_schema(
+                    m_gstate->get_input_schema(), {}
+                );
+                update_context_from_state<t_ctxunit>(
+                    ctx,
+                    name,
+                    m_gstate->get_pkeyed_table(
+                        narrow_schema, m_gstate->get_table()
+                    ),
+                    true
+                );
             }
         } break;
         case GROUPED_PKEY_CONTEXT: {
@@ -1116,7 +1226,7 @@ t_gnode::_register_context(
                 );
 
                 update_context_from_state<t_ctx_grouped_pkey>(
-                    ctx, name, pkeyed_table
+                    ctx, name, m_gstate->get_pkeyed_table(), true
                 );
             }
         } break;

--- a/rust/perspective-server/cpp/perspective/src/cpp/gnode_state.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/gnode_state.cpp
@@ -119,7 +119,7 @@ t_gstate::lookup_or_create(const t_tscalar& pkey) {
 }
 
 void
-t_gstate::fill_master_table(const t_data_table* flattened) {
+t_gstate::fill_master_table(const std::shared_ptr<t_data_table>& flattened) {
     // insert into empty `m_table`
     m_free.clear();
     m_mapping.clear();
@@ -137,16 +137,14 @@ t_gstate::fill_master_table(const t_data_table* flattened) {
     parallel_for(
         int(ncols),
         [&master_table, &master_table_schema, &flattened](int idx) {
-            // Clone each column from flattened into `m_table`
+            // Alias each column `shared_ptr` from flattened into `m_table`
+            // rather than deep-cloning.
             const std::string& column_name = master_table_schema.m_columns[idx];
-            // No need for safe lookup as master_table schema == flattened
-            // schema
-            const t_column* flattened_column =
-                flattened->_get_const_column_safe(column_name);
+            auto flattened_column = flattened->get_column_safe(column_name);
             if (!flattened_column) {
                 return;
             }
-            master_table->set_column(idx, flattened_column->clone());
+            master_table->set_column(idx, std::move(flattened_column));
         }
     );
 
@@ -187,7 +185,54 @@ t_gstate::fill_master_table(const t_data_table* flattened) {
 }
 
 void
-t_gstate::update_master_table(const t_data_table* flattened) {
+t_gstate::init_from_table(const std::shared_ptr<t_data_table>& source) {
+    // Bulk-init the master table directly from `source`. Assumes:
+    //   - master table is empty
+    //   - all rows are `OP_INSERT`
+    //   - `psp_pkey` has no duplicates
+    //
+    // Column `shared_ptr`s are aliased rather than deep-cloned.
+    m_free.clear();
+    m_mapping.clear();
+
+    const t_schema& master_table_schema = m_table->get_schema();
+    t_uindex ncols = m_table->num_columns();
+    auto* master_table = m_table.get();
+
+    parallel_for(
+        int(ncols),
+        [&master_table, &master_table_schema, &source](int idx) {
+            const std::string& column_name = master_table_schema.m_columns[idx];
+            auto src_col = source->get_column_safe(column_name);
+            if (!src_col) {
+                return;
+            }
+            master_table->set_column(idx, std::move(src_col));
+        }
+    );
+
+    m_pkcol = master_table->get_column("psp_pkey");
+    m_opcol = master_table->get_column("psp_op");
+
+    master_table->set_capacity(source->get_capacity());
+    master_table->set_size(source->size());
+
+    const t_column* pkey_col = master_table->_get_const_column("psp_pkey");
+    for (t_uindex idx = 0, loop_end = source->num_rows(); idx < loop_end;
+         ++idx) {
+        t_tscalar pkey = pkey_col->get_scalar(idx);
+        m_mapping.emplace(m_symtable.get_interned_tscalar(pkey), idx);
+    }
+
+#ifdef PSP_TABLE_VERIFY
+    master_table->verify();
+#endif
+}
+
+void
+t_gstate::update_master_table(
+    const std::shared_ptr<t_data_table>& flattened
+) {
     if (num_rows() == 0) {
         fill_master_table(flattened);
         return;

--- a/rust/perspective-server/cpp/perspective/src/cpp/server.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/server.cpp
@@ -2892,13 +2892,17 @@ ProtoServer::_handle_request(std::uint32_t client_id, Request&& req) {
 
             proto::Response resp;
             auto* arrow = resp.mutable_view_to_arrow_resp()->mutable_arrow();
+            bool legacy_names = r.viewport().has_emit_legacy_row_path_names()
+                ? r.viewport().emit_legacy_row_path_names()
+                : true;
             *arrow = *view->to_arrow(
                 dims.start_row,
                 dims.end_row,
                 dims.start_col,
                 dims.end_col,
                 true,
-                r.compression() == "lz4"
+                r.compression() == "lz4",
+                legacy_names
             );
 
             push_resp(std::move(resp));

--- a/rust/perspective-server/cpp/perspective/src/cpp/table.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/table.cpp
@@ -83,6 +83,28 @@ Table::init(
     m_init = true;
 }
 
+void
+Table::init_bulk(
+    const std::shared_ptr<t_data_table>& data_table,
+    std::uint32_t row_count
+) {
+    PSP_VERBOSE_ASSERT(
+        !m_gnode_set,
+        "`init_bulk` can only be used for the initial load of a `Table`."
+    );
+
+    process_op_column(*data_table, t_op::OP_INSERT);
+    calculate_offset(row_count);
+
+    auto new_gnode = make_gnode(data_table->get_schema());
+    set_gnode(new_gnode);
+    m_pool->register_gnode(m_gnode.get());
+
+    m_gnode->init_bulk(data_table);
+
+    m_init = true;
+}
+
 t_uindex
 Table::size() const {
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
@@ -368,16 +390,19 @@ Table::from_csv(
     apachearrow::ArrowLoader arrow_loader;
     arrow_loader.init_csv(data, false, map);
 
-    std::vector<std::string> column_names;
-    std::vector<t_dtype> data_types;
+    // Arrow has materialized the CSV into its own buffers at this point; drop
+    // the raw CSV string so it does not live concurrently with the Arrow table
+    // and the `t_data_table`.
+    { auto _ = std::move(data); }
 
-    column_names = arrow_loader.names();
-    data_types = arrow_loader.types();
+    std::vector<std::string> column_names = arrow_loader.names();
+    std::vector<t_dtype> data_types = arrow_loader.types();
     t_schema input_schema(column_names, data_types);
     auto implicit_index_it =
         std::find(column_names.begin(), column_names.end(), "__INDEX__");
+    const bool has_index_column = implicit_index_it != column_names.end();
 
-    if (implicit_index_it != column_names.end()) {
+    if (has_index_column) {
         auto idx = std::distance(column_names.begin(), implicit_index_it);
         // position of the column is at the same index in both vectors
         column_names.erase(column_names.begin() + idx);
@@ -385,26 +410,34 @@ Table::from_csv(
     }
 
     t_schema output_schema(column_names, data_types);
-    std::uint32_t row_count = 0;
-    row_count = arrow_loader.row_count();
+    std::uint32_t row_count = arrow_loader.row_count();
 
     auto data_table = std::make_shared<t_data_table>(output_schema);
     data_table->init();
 
     {
-        auto _ = std::move(data);
         auto loader = std::move(arrow_loader);
         data_table->extend(row_count);
         loader.fill_table(*data_table, input_schema, index, 0, false);
     }
+
     auto pool = std::make_shared<t_pool>();
     pool->init();
     auto tbl =
         std::make_shared<Table>(pool, column_names, data_types, limit, index);
 
-    tbl->init(*data_table, row_count, t_op::OP_INSERT, 0);
-    data_table.reset();
-    pool->_process();
+    // `psp_pkey` is guaranteed unique only when the index is implicit (a
+    // generated row-number). Explicit indexes or `__INDEX__` columns can
+    // contain duplicates, which must be deduplicated via the `flatten()`
+    // path.
+    const bool can_bulk_init = index.empty() && !has_index_column;
+    if (can_bulk_init) {
+        tbl->init_bulk(data_table, row_count);
+    } else {
+        tbl->init(*data_table, row_count, t_op::OP_INSERT, 0);
+        data_table.reset();
+        pool->_process();
+    }
     return tbl;
 }
 

--- a/rust/perspective-server/cpp/perspective/src/cpp/view.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/view.cpp
@@ -755,14 +755,15 @@ View<CTX_T>::to_arrow(
     std::int32_t start_col,
     std::int32_t end_col,
     bool emit_group_by,
-    bool compress
+    bool compress,
+    bool emit_legacy_row_path_names
 ) const {
     PSP_GIL_UNLOCK();
     PSP_READ_LOCK(*get_lock());
 
     std::shared_ptr<t_data_slice<CTX_T>> data_slice =
         get_data(start_row, end_row, start_col, end_col);
-    return data_slice_to_arrow(data_slice, emit_group_by, compress);
+    return data_slice_to_arrow(data_slice, emit_group_by, compress, emit_legacy_row_path_names);
 };
 
 template <>
@@ -826,7 +827,8 @@ View<CTX_T>::to_csv(
 template <typename CTX_T>
 std::pair<std::shared_ptr<arrow::Schema>, std::shared_ptr<arrow::RecordBatch>>
 View<CTX_T>::data_slice_to_batches(
-    bool emit_group_by, std::shared_ptr<t_data_slice<CTX_T>> data_slice
+    bool emit_group_by, std::shared_ptr<t_data_slice<CTX_T>> data_slice,
+    bool emit_legacy_row_path_names
 ) const {
     // From the data slice, get all the metadata we need
     t_get_data_extents extents = data_slice->get_data_extents();
@@ -856,10 +858,17 @@ View<CTX_T>::data_slice_to_batches(
         auto schema = m_table->get_schema();
         for (auto rpidx = 0; rpidx < num_row_paths; ++rpidx) {
             std::string column_name = row_pivots.at(rpidx);
-            std::string row_path_name = column_name;
-            row_path_name += " (Group by ";
-            row_path_name += std::to_string(rpidx + 1);
-            row_path_name += ")";
+            std::string row_path_name;
+            if (emit_legacy_row_path_names) {
+                row_path_name = column_name;
+                row_path_name += " (Group by ";
+                row_path_name += std::to_string(rpidx + 1);
+                row_path_name += ")";
+            } else {
+                row_path_name = "__ROW_PATH_";
+                row_path_name += std::to_string(rpidx);
+                row_path_name += "__";
+            }
 
             // Get the "table" type for this column, as row_pivots are not in
             // the view schema.
@@ -1344,12 +1353,13 @@ std::shared_ptr<std::string>
 View<CTX_T>::data_slice_to_arrow(
     std::shared_ptr<t_data_slice<CTX_T>> data_slice,
     bool emit_group_by,
-    bool compress
+    bool compress,
+    bool emit_legacy_row_path_names
 ) const {
     std::pair<
         std::shared_ptr<arrow::Schema>,
         std::shared_ptr<arrow::RecordBatch>>
-        pairs = data_slice_to_batches(emit_group_by, data_slice);
+        pairs = data_slice_to_batches(emit_group_by, data_slice, emit_legacy_row_path_names);
     std::shared_ptr<arrow::RecordBatch> batches = pairs.second;
     std::shared_ptr<arrow::Schema> arrow_schema = pairs.first;
     arrow::Result<std::shared_ptr<arrow::ResizableBuffer>> allocated =

--- a/rust/perspective-server/cpp/perspective/src/include/perspective/context_common_decls.h
+++ b/rust/perspective-server/cpp/perspective/src/include/perspective/context_common_decls.h
@@ -24,8 +24,11 @@ void sort_by(const std::vector<t_sortspec>& sortby);
 
 void reset_sortby();
 
-// will only work on empty contexts
-void notify(const t_data_table& flattened);
+// will only work on empty contexts. `is_registration` is `true` when this
+// call is part of `_register_context` (no subscriber yet) and `false` when
+// it is the first update to a previously-empty table. When `true`, per-row
+// delta tracking is skipped to avoid O(N) allocations no observer can see.
+void notify(const t_data_table& flattened, bool is_registration);
 
 void notify(
     const t_data_table& flattened,

--- a/rust/perspective-server/cpp/perspective/src/include/perspective/context_unit.h
+++ b/rust/perspective-server/cpp/perspective/src/include/perspective/context_unit.h
@@ -67,8 +67,12 @@ public:
 
     std::vector<t_tscalar> get_data(const std::vector<t_tscalar>& pkeys) const;
 
-    // will only work on empty contexts
-    void notify(const t_data_table& flattened);
+    // will only work on empty contexts. `is_registration` is `true` when
+    // this call is part of `_register_context` (no subscriber yet) and
+    // `false` when it is the first update to a previously-empty table.
+    // When `true`, per-row delta tracking is skipped to avoid O(N)
+    // allocations no observer can see.
+    void notify(const t_data_table& flattened, bool is_registration);
 
     void notify(
         const t_data_table& flattened,

--- a/rust/perspective-server/cpp/perspective/src/include/perspective/flat_traversal.h
+++ b/rust/perspective-server/cpp/perspective/src/include/perspective/flat_traversal.h
@@ -120,6 +120,22 @@ public:
     std::vector<t_sortspec> get_sort_by() const;
     bool empty_sort_by() const;
 
+    // Fast-path initialization for unsorted traversals: append pkeys
+    // directly to `m_index` in one shot, skipping the `m_new_elems`
+    // hopscotch_map round-trip and the `new_rows` intermediate vector
+    // that a normal `add_row` / `step_end` pair would incur. Only valid
+    // when `empty_sort_by()` is true and the traversal is otherwise empty
+    // (i.e. during initial registration of a ctx0 without a sort).
+    //
+    // Call `bulk_load_reserve(n)` first, then `bulk_load_append(pkey)`
+    // once per pkey, then `bulk_load_finalize()` to sort by pkey (the
+    // implicit order used by `cmp_mselem` with an empty sort spec) and
+    // build `m_pkeyidx`. After finalize, `step_end` short-circuits
+    // because `m_step_inserts` remains 0.
+    void bulk_load_reserve(t_uindex n);
+    void bulk_load_append(t_tscalar pkey);
+    void bulk_load_finalize();
+
     void reset_step_state();
 
     t_uindex lower_bound_row_idx(

--- a/rust/perspective-server/cpp/perspective/src/include/perspective/gnode.h
+++ b/rust/perspective-server/cpp/perspective/src/include/perspective/gnode.h
@@ -109,6 +109,21 @@ public:
     void send(t_uindex port_id, const t_data_table& fragments);
 
     /**
+     * @brief Bulk-initialize an empty gnode directly from `data_table`,
+     * bypassing the input port, `flatten()`, and `update_master_table()`
+     * pipeline.
+     *
+     * The caller must guarantee that (a) the gnode's gstate is empty,
+     * (b) all rows are `OP_INSERT`, and (c) `psp_pkey` contains no
+     * duplicates (e.g. an implicit row-index primary key). Columns of
+     * `data_table` are aliased into the master table instead of being
+     * copied.
+     *
+     * @param data_table
+     */
+    void init_bulk(const std::shared_ptr<t_data_table>& data_table);
+
+    /**
      * @brief Given a port_id, call `process_table` on the port's data table,
      * reconciling all queued calls to `update` and `remove` on that port.
      * Returns a boolean indicating whether the update was valid and whether
@@ -254,7 +269,8 @@ protected:
     void update_context_from_state(
         CTX_T* ctx,
         const std::string& name,
-        std::shared_ptr<t_data_table> flattened
+        std::shared_ptr<t_data_table> flattened,
+        bool is_registration
     );
 
     /**
@@ -484,7 +500,10 @@ t_gnode::notify_context(
 template <typename CTX_T>
 void
 t_gnode::update_context_from_state(
-    CTX_T* ctx, const std::string& name, std::shared_ptr<t_data_table> flattened
+    CTX_T* ctx,
+    const std::string& name,
+    std::shared_ptr<t_data_table> flattened,
+    bool is_registration
 ) {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
@@ -503,9 +522,14 @@ t_gnode::update_context_from_state(
     //
     // 1. when a new context is created and it needs to get the current state
     //  of the gstate master table in order to calculate aggregates, etc.
+    //  `is_registration` is `true` in this case — no subscriber can observe
+    //  deltas populated during this initial notify, so we skip populating
+    //  `m_delta_pkeys` to save O(N) allocations.
     //
     // 2. when a table created from schema (0 rows) gets data and now needs
-    //  to update its registered contexts with the new data.
+    //  to update its registered contexts with the new data. `is_registration`
+    //  is `false` here — a subscriber may have attached between context
+    //  creation and the first update, and expects to see all rows as deltas.
     if (ctx->num_expressions() > 0) {
         // If the context has expression columns, it has already been computed
         // in `process_table` and we can join the "real" and expression columns
@@ -514,10 +538,10 @@ t_gnode::update_context_from_state(
             ctx->get_expression_tables();
         std::shared_ptr<t_data_table> joined_flattened =
             flattened->join(ctx_expression_tables->m_flattened);
-        ctx->notify(*joined_flattened);
+        ctx->notify(*joined_flattened, is_registration);
     } else {
         // Just use the table from the gnode
-        ctx->notify(*flattened);
+        ctx->notify(*flattened, is_registration);
     }
 
     ctx->step_end();

--- a/rust/perspective-server/cpp/perspective/src/include/perspective/gnode_state.h
+++ b/rust/perspective-server/cpp/perspective/src/include/perspective/gnode_state.h
@@ -67,9 +67,13 @@ public:
     /**
      * @brief If the master table has 0 rows, fill it using `flattened`.
      *
+     * Aliases `flattened`'s column `shared_ptr`s into the master table instead
+     * of memcpy-cloning them; callers that still hold references to
+     * `flattened` must not mutate it after this call.
+     *
      * @param flattened
      */
-    void fill_master_table(const t_data_table* flattened);
+    void fill_master_table(const std::shared_ptr<t_data_table>& flattened);
 
     /**
      * @brief Update the master `t_data_table` with the flattened and masked
@@ -78,7 +82,19 @@ public:
      *
      * @param flattened
      */
-    void update_master_table(const t_data_table* flattened);
+    void update_master_table(const std::shared_ptr<t_data_table>& flattened);
+
+    /**
+     * @brief Bulk-initialize the master table directly from `source`, bypassing
+     * the flatten/merge pipeline.
+     *
+     * Requires the master table to be empty, all rows in `source` to be
+     * `OP_INSERT`, and the `psp_pkey` column of `source` to contain no
+     * duplicates. Column `shared_ptr`s are aliased into the master table.
+     *
+     * @param source
+     */
+    void init_from_table(const std::shared_ptr<t_data_table>& source);
 
     /**
      * @brief Given a column in the master data table and the corresponding

--- a/rust/perspective-server/cpp/perspective/src/include/perspective/server.h
+++ b/rust/perspective-server/cpp/perspective/src/include/perspective/server.h
@@ -159,7 +159,8 @@ namespace server {
             t_uindex start_col,
             t_uindex end_col,
             bool emit_group_by = true,
-            bool compress = true
+            bool compress = true,
+            bool emit_legacy_row_path_names = true
         ) const = 0;
 
         [[nodiscard]]
@@ -291,10 +292,11 @@ namespace server {
             t_uindex start_col,
             t_uindex end_col,
             bool emit_group_by = true,
-            bool compress = true
+            bool compress = true,
+            bool emit_legacy_row_path_names = true
         ) const override {
             return m_view->to_arrow(
-                start_row, end_row, start_col, end_col, emit_group_by, compress
+                start_row, end_row, start_col, end_col, emit_group_by, compress, emit_legacy_row_path_names
             );
         }
 

--- a/rust/perspective-server/cpp/perspective/src/include/perspective/table.h
+++ b/rust/perspective-server/cpp/perspective/src/include/perspective/table.h
@@ -72,6 +72,26 @@ public:
     );
 
     /**
+     * @brief Fast-path `init` for the initial bulk load of an empty `Table`.
+     *
+     * Aliases `data_table`'s columns directly into the gnode's master table,
+     * skipping the input port append + `flatten()` copies that `init` would
+     * otherwise perform. Only valid when the gnode has not yet been created
+     * (no prior data) and the caller can guarantee that `psp_pkey` contains
+     * no duplicates -- e.g. `from_csv` with an implicit row-index pkey.
+     *
+     * Also skips the subsequent `pool->_process()` call, since nothing is
+     * queued on the input port.
+     *
+     * @param data_table
+     * @param row_count
+     */
+    void init_bulk(
+        const std::shared_ptr<t_data_table>& data_table,
+        std::uint32_t row_count
+    );
+
+    /**
      * @brief The size of the underlying `t_data_table`, i.e. a row count
      *
      * @return t_uindex

--- a/rust/perspective-server/cpp/perspective/src/include/perspective/view.h
+++ b/rust/perspective-server/cpp/perspective/src/include/perspective/view.h
@@ -277,7 +277,8 @@ public:
         std::int32_t start_col,
         std::int32_t end_col,
         bool emit_group_by,
-        bool compress
+        bool compress,
+        bool emit_legacy_row_path_names = true
     ) const;
 
     /**
@@ -312,7 +313,8 @@ public:
     std::shared_ptr<std::string> data_slice_to_arrow(
         std::shared_ptr<t_data_slice<CTX_T>> data_slice,
         bool emit_group_b,
-        bool compress
+        bool compress,
+        bool emit_legacy_row_path_names = true
     ) const;
 
     /**
@@ -427,7 +429,8 @@ private:
         std::shared_ptr<arrow::Schema>,
         std::shared_ptr<arrow::RecordBatch>>
     data_slice_to_batches(
-        bool emit_group_by, std::shared_ptr<t_data_slice<CTX_T>> data_slice
+        bool emit_group_by, std::shared_ptr<t_data_slice<CTX_T>> data_slice,
+        bool emit_legacy_row_path_names = true
     ) const;
 
     void _find_hidden_sort(const std::vector<t_sortspec>& sort);

--- a/rust/perspective-viewer/src/rust/lib.rs
+++ b/rust/perspective-viewer/src/rust/lib.rs
@@ -66,6 +66,7 @@ import type {
     TableInitOptions, 
     ColumnWindow,
     ViewWindow, 
+    TypedArrayWindow,
     OnUpdateOptions,
     JoinOptions,
     UpdateOptions,

--- a/tools/bench/cross_platform_suite.mjs
+++ b/tools/bench/cross_platform_suite.mjs
@@ -17,7 +17,7 @@ import {
 } from "./src/js/superstore.mjs";
 
 export async function join_suite(perspective, metadata) {
-    if (check_version_gte(metadata.version, "4.3.0")) {
+    if (check_version_gte(metadata.version, "4.4.0")) {
         async function before_all() {
             const left = await perspective.table(
                 new_superstore_table(metadata),

--- a/tools/bench/package.json
+++ b/tools/bench/package.json
@@ -26,6 +26,8 @@
         "zx": "catalog:"
     },
     "dependencies": {
+        "perspective-4-4-0": "npm:@perspective-dev/client@4.4.0",
+        "perspective-4-3-0": "npm:@perspective-dev/client@4.3.0",
         "perspective-4-2-0": "npm:@perspective-dev/client@4.2.0",
         "perspective-4-1-0": "npm:@perspective-dev/client@4.1.0",
         "perspective-4-0-0": "npm:@perspective-dev/client@4.0.0",

--- a/tools/scripts/bench.mjs
+++ b/tools/scripts/bench.mjs
@@ -12,13 +12,14 @@
 
 import * as dotenv from "dotenv";
 import { get_scope } from "./sh_perspective.mjs";
+import { execSync } from "node:child_process";
 
 import "zx/globals";
 
 dotenv.config({ path: "./.perspectiverc", quiet: true });
 const scope = get_scope();
 if (scope.includes("client")) {
-    $.sync`pnpm run --recursive --filter bench bench_js`;
+    await $`pnpm run --recursive --filter bench bench_js`.pipe(process.stdout);
 } else if (scope.includes("python")) {
     $.sync`pnpm run --recursive --filter bench bench_python`;
 }


### PR DESCRIPTION
This PR mainly add `View.with_typed_arrays`, a new zero-copy JS API([febaf25f5](febaf25f5ef211321b9bc5e32f427349865b11cd)):

- New `with_typed_arrays(window, callback)` on the JS `View`. Calls `callback(names, values, validities, dictionaries)` with zero-copy `TypedArray` views over the Arrow buffers. Numeric columns map 1:1 to `Int32Array`/`Uint32Array`/`Float32Array`/`Float64Array`; `Dictionary<Int32, Utf8>` columns surface as `(Int32Array keys, string[] values)` pairs; validity bitmaps are `Uint8Array` views. Arrays are only valid inside the callback.
- `float32` option downcasts `Float64`/`Date32`/`Timestamp`/`Int64` columns to `Float32Array` for half-memory GPU uploads.
- New `ViewWindow.emit_legacy_row_path_names`, when `false`, group-by columns are named `__ROW_PATH_N__` to match the SQL backend; `with_typed_arrays` forces this off. Wired through protobuf (`ViewPort.emit_legacy_row_path_names`) and `View::to_arrow`. This is helpful to make sense of which columns are which, if you don't need them to be human readable.

As a drive-by, the internals of `View` registration have been optimized for memory and CPU performance, originally an experient to share state between `Table` and `View` when their columns would otherwise be identical (e.g. `ctx0`), that spilled over into all `View` loading and glanced CSV loading as well:

- `t_ctx0`/`t_ctx1`/`t_ctx2`/`t_ctxunit` - skip populating `m_delta_pkeys` (saves a hopscotch_set insert per row).
- `t_ctx0`: new bulk-load fast path for unsorted/unfiltered/empty traversal — appends pkeys directly into `m_index` via new `t_ftrav::bulk_load_reserve/append/finalize`, skipping the `m_new_elems` hopscotch_map round-trip. `t_ftrav::step_end` now short-circuits when no step work happened.
- New `Table::init_bulk` API that aliases `shared_ptr<t_column>`s into the master table instead of deep-cloning. Preconditions: empty gstate, all `OP_INSERT`, unique `psp_pkey`.
- `Table::from_csv` uses the new bulk path when the index is implicit (no explicit index, no `__INDEX__`); otherwise falls back to the flatten-and-merge path, since those allow duplicate pkeys.
- `fill_master_table` / `update_master_table` now take `shared_ptr<t_data_table>` and alias columns (zero-copy) instead of `clone()`-ing each column.
