### PR TITLE
fix(client): preserve underscores in SQL column aliases

### DIFF
--- a/rust/perspective-client/src/rust/virtual_server/generic_sql_model/table_make_view.rs
+++ b/rust/perspective-client/src/rust/virtual_server/generic_sql_model/table_make_view.rs
@@ -380,7 +380,7 @@ impl<'a> ViewQueryContext<'a> {
         if self.needs_aggregation() {
             for col in self.config.columns.iter().flatten() {
                 let agg = self.get_aggregate(col);
-                let escaped = col.replace('"', "\"\"").replace("_", "-");
+                let escaped = col.replace('"', "\"\"");
                 clauses.push(format!(
                     "{}({}) as \"{}\"",
                     agg,
@@ -390,7 +390,7 @@ impl<'a> ViewQueryContext<'a> {
             }
         } else if !self.config.columns.is_empty() {
             for col in self.config.columns.iter().flatten() {
-                let escaped = col.replace('"', "\"\"").replace("_", "-");
+                let escaped = col.replace('"', "\"\"");
                 clauses.push(format!("{} as \"{}\"", self.col_name(col), escaped));
             }
         }

--- a/rust/perspective-client/src/rust/virtual_server/generic_sql_model/tests.rs
+++ b/rust/perspective-client/src/rust/virtual_server/generic_sql_model/tests.rs
@@ -63,6 +63,27 @@ fn test_table_make_view_simple() {
 }
 
 #[test]
+fn test_table_make_view_preserves_underscores_in_flat_column_alias() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    let mut config = ViewConfig::default();
+    config.columns = vec![Some("account_number".to_string())];
+    let sql = builder
+        .table_make_view("source_table", "dest_view", &config)
+        .unwrap();
+
+    assert!(
+        sql.contains("\"account_number\" as \"account_number\""),
+        "expected underscores to be preserved in flat column alias: {}",
+        sql
+    );
+    assert!(
+        !sql.contains("\"account-number\""),
+        "expected hyphenated column alias to be absent: {}",
+        sql
+    );
+}
+
+#[test]
 fn test_table_make_view_with_group_by() {
     let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
     let mut config = ViewConfig::default();
@@ -75,6 +96,28 @@ fn test_table_make_view_with_group_by() {
     assert!(sql.contains("GROUP BY ROLLUP"));
     assert!(sql.contains("__ROW_PATH_0__"));
     assert!(sql.contains("__GROUPING_ID__"));
+}
+
+#[test]
+fn test_table_make_view_preserves_underscores_in_aggregate_column_alias() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    let mut config = ViewConfig::default();
+    config.columns = vec![Some("account_number".to_string())];
+    config.group_by = vec!["category".to_string()];
+    let sql = builder
+        .table_make_view("source_table", "dest_view", &config)
+        .unwrap();
+
+    assert!(
+        sql.contains("any_value(\"account_number\") as \"account_number\""),
+        "expected underscores to be preserved in aggregate column alias: {}",
+        sql
+    );
+    assert!(
+        !sql.contains("\"account-number\""),
+        "expected hyphenated column alias to be absent: {}",
+        sql
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

Preserves underscores in column aliases generated by `GenericSQLVirtualServerModel`. The SQL builder previously replaced `_` with `-`, so selecting `account_number` produced an alias named `account-number` and changed the schema exposed to clients.

The fix keeps the original identifier while continuing to escape embedded double quotes. Regression tests cover both flat and aggregated view queries.

Fixes #3187.

## Validation

- `cargo test --features generate-proto,omit_metadata generic_sql_model --no-default-features` (25 passing)
- `rustfmt --check` on the changed Rust files
- `git diff --check origin/master...HEAD`

## Tooling assistance

Codex assisted with implementation and local validation. I reviewed the resulting diff and test output.
