### PR TITLE
fix(server): serialize dates at UTC midnight

### DIFF
--- a/rust/perspective-python/perspective/tests/table/test_to_format.py
+++ b/rust/perspective-python/perspective/tests/table/test_to_format.py
@@ -11,7 +11,8 @@
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import os
-from datetime import date, datetime
+import time
+from datetime import date, datetime, timezone
 from io import StringIO
 
 import numpy as np
@@ -242,6 +243,27 @@ class TestToFormat(object):
             "a": [util.to_timestamp(dt), util.to_timestamp(dt)],
             "b": [2, 4],
         }
+
+    @mark.skipif(IS_WIN, reason="time.tzset() is not available on Windows")
+    def test_to_columns_date_uses_utc_midnight(self, monkeypatch):
+        original_tz = os.environ.get("TZ")
+        monkeypatch.setenv("TZ", "Europe/Amsterdam")
+        time.tzset()
+
+        try:
+            tbl = Table({"a": "date"})
+            tbl.update({"a": ["2024-01-01"]})
+            expected = int(datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+            view = tbl.view()
+            assert view.to_columns() == {"a": [expected]}
+            assert view.to_csv() == '"a"\n2024-01-01\n'
+        finally:
+            if original_tz is None:
+                monkeypatch.delenv("TZ")
+            else:
+                monkeypatch.setenv("TZ", original_tz)
+
+            time.tzset()
 
     def test_to_columns_datetime(self, util):
         dt = datetime(2019, 3, 15, 20, 30, 59, 6000)

--- a/rust/perspective-server/cpp/perspective/src/cpp/scalar.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/scalar.cpp
@@ -1109,12 +1109,7 @@ t_tscalar::to_string(bool for_expr) const {
 
                 return ss.str();
             }
-            t_date date_val = get<t_date>();
-            tm t = date_val.get_tm();
-            time_t epoch_delta = mktime(&t);
-            std::chrono::milliseconds timestamp(epoch_delta * 1000);
-            date::sys_time<std::chrono::milliseconds> ts(timestamp);
-            return date::format("%F", ts);
+            return get<t_date>().str();
 
         } break;
         case DTYPE_BOOL: {

--- a/rust/perspective-server/cpp/perspective/src/cpp/view.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/view.cpp
@@ -1859,9 +1859,19 @@ write_scalar(
                 writer.String(scalar.to_string().c_str());
             } else {
                 t_date date_val = scalar.get<t_date>();
-                tm t = date_val.get_tm();
-                time_t epoch_delta = mktime(&t);
-                writer.Int64(epoch_delta * 1000);
+                date::year year{date_val.year()};
+                date::month month{
+                    static_cast<std::uint32_t>(date_val.month() + 1)
+                };
+                date::day day{static_cast<std::uint32_t>(date_val.day())};
+                date::sys_days utc_date =
+                    date::year_month_day(year, month, day);
+                writer.Int64(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                        utc_date.time_since_epoch()
+                    )
+                        .count()
+                );
             }
             break;
         }


### PR DESCRIPTION
## Description

Serializes Perspective `date` values as UTC calendar days instead of converting local midnight with `mktime()`. In positive-offset time zones, the previous conversion shifted a date such as `2024-01-01` to the previous UTC day. Formatted date output now uses the stored calendar value directly.

The regression test fixes the process timezone to `Europe/Amsterdam` and verifies both the numeric UTC-midnight value and CSV output.

Fixes #3106.

## Validation

- Changed native C++ translation units compiled successfully
- `test_to_format.py` (91 passed, 17 skipped)
- Ruff check and format check for the changed Python test
- Post-fix runtime verification for JSON and CSV output
- `git diff --check origin/master...HEAD`

## Tooling assistance

Codex assisted with implementation and local validation. I reviewed the resulting diff and test output.
