### PR TITLE
Fix `date` type timezone error

### DIFF
--- a/docs/md/how_to/python/table.md
+++ b/docs/md/how_to/python/table.md
@@ -79,3 +79,12 @@ Python `datetime` objects are serialized to strings before parsing. Naive
 `datetime` objects (without `tzinfo`) produce strings without timezone
 information and are therefore treated as UTC. Timezone-aware `datetime` objects
 include their offset in the serialized string, which is used to convert to UTC.
+
+`"date"` values are timezone-agnostic calendar days with no time component.
+They are _output_ as integer timestamps at _UTC midnight_ of the calendar day
+(equivalent to Arrow `date32` day arithmetic), and integer timestamp _input_ to
+a `"date"` column is likewise interpreted as UTC. The host process timezone
+never affects `"date"` values — a `Viewer` renders them in UTC, recovering the
+stored calendar day exactly. Datetime expression functions such as
+`bucket("x", 'D')`, `day_of_week("x")` and `hour_of_day("x")` also compute in
+UTC.

--- a/rust/perspective-js/test/js/constructors/date_timezone.spec.ts
+++ b/rust/perspective-js/test/js/constructors/date_timezone.spec.ts
@@ -1,0 +1,111 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { test, expect } from "@perspective-dev/test";
+import perspective from "../perspective_client";
+
+const JAN_1_2024_UTC = 1704067200000;
+
+test.describe("Date timezone invariance", function () {
+    let SAVED_TZ: string | undefined;
+
+    test.beforeEach(() => {
+        SAVED_TZ = process.env.TZ;
+        process.env.TZ = "Europe/Amsterdam";
+    });
+
+    test.afterEach(() => {
+        process.env.TZ = SAVED_TZ;
+    });
+
+    test("date strings serialize to UTC midnight epoch ms", async function () {
+        const table = await perspective.table({ d: "date" });
+        await table.update({ d: ["2024-01-01"] });
+        const view = await table.view();
+        const cols = (await view.to_columns()) as { d: number[] };
+        expect(cols.d).toEqual([JAN_1_2024_UTC]);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("date epoch ms input round-trips exactly", async function () {
+        const table = await perspective.table({ d: "date" });
+        await table.update({ d: [JAN_1_2024_UTC] });
+        const view = await table.view();
+        const cols = (await view.to_columns()) as { d: number[] };
+        expect(cols.d).toEqual([JAN_1_2024_UTC]);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("formatted output prints the stored calendar day", async function () {
+        const table = await perspective.table({ d: "date" });
+        await table.update({ d: ["2024-01-01"] });
+        const view = await table.view();
+        expect(await view.to_columns_string({ formatted: true })).toEqual(
+            '{"d":["2024-01-01"]}',
+        );
+        expect(await view.to_csv()).toEqual('"d"\n2024-01-01\n');
+        await view.delete();
+        await table.delete();
+    });
+
+    test("day_bucket stays on the UTC calendar day at the day boundary", async function () {
+        const table = await perspective.table({ t: "datetime" });
+
+        // 23:59 UTC is already the next day in Europe/Amsterdam
+        await table.update({ t: ["2020-01-31 23:59:00"] });
+        const view = await table.view({
+            expressions: { bucket: `bucket("t", 'D')` },
+        });
+
+        const cols = (await view.to_columns()) as { bucket: number[] };
+
+        // 2020-01-31T00:00:00Z
+        expect(cols.bucket).toEqual([1580428800000]);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("day_of_week and hour_of_day compute in UTC", async function () {
+        const table = await perspective.table({ t: "datetime" });
+        await table.update({ t: ["2020-01-31 23:59:00"] });
+        const view = await table.view({
+            expressions: {
+                dow: `day_of_week("t")`,
+                hod: `hour_of_day("t")`,
+            },
+        });
+
+        const cols = (await view.to_columns()) as {
+            dow: string[];
+            hod: number[];
+        };
+
+        // Friday 23:00 UTC, not Saturday 00:59 Amsterdam
+        expect(cols.dow).toEqual(["6 Friday"]);
+        expect(cols.hod).toEqual([23]);
+        await view.delete();
+        await table.delete();
+    });
+
+    test("JSON date output agrees with Arrow date32 day arithmetic", async function () {
+        const table = await perspective.table({ d: "date" });
+        await table.update({ d: ["2024-01-01"] });
+        const view = await table.view();
+        const cols = (await view.to_columns()) as { d: number[] };
+        expect(cols.d[0] % 86400000).toEqual(0);
+        expect(cols.d[0] / 86400000).toEqual(19723); // days since epoch
+        await view.delete();
+        await table.delete();
+    });
+});

--- a/rust/perspective-python/docs/lib.md
+++ b/rust/perspective-python/docs/lib.md
@@ -153,15 +153,14 @@ table = perspective.table(data, index="index")
 
 #### Time Zone Handling
 
-When parsing `"datetime"` strings, times are assumed _local time_ unless an
-explicit timezone offset is parsed. All `"datetime"` columns (regardless of
-input time zone) are _output_ to the user as `datetime.datetime` objects in
-_local time_ according to the Python runtime.
-
-This behavior is consistent with Perspective's behavior in JavaScript. For more
-details, see this in-depth
-[explanation](https://github.com/perspective-dev/perspective/pull/867) of
-`perspective-python` semantics around time zone handling.
+When parsing `"datetime"` strings, times without an explicit timezone offset are
+interpreted as _UTC_; strings with an offset are converted to UTC. All
+`"datetime"` values are stored internally as milliseconds since the Unix epoch
+and are _output_ as integer timestamps from methods like `to_columns()` and
+`to_json()`. `"date"` values are timezone-agnostic calendar days, output as
+integer timestamps at _UTC midnight_ of the calendar day. The host process
+timezone never affects engine results; localization is the display layer's
+responsibility.
 
 ### Callbacks and Events
 

--- a/rust/perspective-python/perspective/tests/conftest.py
+++ b/rust/perspective-python/perspective/tests/conftest.py
@@ -10,7 +10,7 @@
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 
 import numpy as np
 import pandas as pd
@@ -165,10 +165,23 @@ class Util:
 
     @staticmethod
     def to_timestamp(obj):
-        """Return an integer timestamp based on a date/datetime object."""
+        """Return an integer timestamp based on a date/datetime object.
+
+        A `date` is a timezone-agnostic calendar day and serializes to epoch
+        ms at *UTC* midnight regardless of the host process timezone, so it
+        is converted here in UTC. A naive `datetime` is a wall-clock reading
+        in the process-local timezone (callers express expected instants
+        this way, e.g. `aware.astimezone(TZ).replace(tzinfo=None)`), so it is
+        converted via local `timestamp()`.
+        """
         classname = obj.__class__.__name__
         if classname == "date":
-            return int(datetime(obj.year, obj.month, obj.day).timestamp() * 1000)
+            return int(
+                datetime(
+                    obj.year, obj.month, obj.day, tzinfo=timezone.utc
+                ).timestamp()
+                * 1000
+            )
         elif classname == "datetime":
             return int(obj.timestamp() * 1000)
         else:

--- a/rust/perspective-python/perspective/tests/table/test_table_datetime.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_datetime.py
@@ -1404,9 +1404,8 @@ if os.name != "nt":
             assert result['hour_of_day("a")'] == [0, 11, 19]
 
         def test_table_day_of_week_edge_in_EST(self):
-            """Make sure edge cases are fixed for day of week - if a local
-            time converted to UTC is in the next day, the day of week
-            computation needs to be in local time."""
+            """Naive datetimes parse as UTC and `day_of_week` is computed in
+            UTC, so the host timezone must not shift the result."""
             data = {"a": [datetime(2020, 1, 31, 23, 59)]}
 
             table = Table(data)
@@ -1437,9 +1436,8 @@ if os.name != "nt":
             assert result['day_of_week("a")'] == ["6 Friday"]
 
         def test_table_month_of_year_edge_in_EST(self):
-            """Make sure edge cases are fixed for month of year - if a local
-            time converted to UTC is in the next month, the month of year
-            computation needs to be in local time."""
+            """Naive datetimes parse as UTC and `month_of_year` is computed in
+            UTC, so the host timezone must not shift the result."""
             data = {"a": [datetime(2020, 1, 31, 23, 59)]}
 
             table = Table(data)
@@ -1470,16 +1468,16 @@ if os.name != "nt":
             assert result['month_of_year("a")'] == ["01 January"]
 
         def test_table_day_bucket_edge_in_EST(self, util):
-            """Make sure edge cases are fixed for day_bucket - if a local
-            time converted to UTC is in the next day, the day_bucket
-            computation needs to be in local time."""
+            """`day_bucket` is computed in UTC and the resulting `date`
+            serializes to UTC midnight, so the host timezone must not shift
+            the bucket or its serialized value."""
             data = {"a": [datetime(2020, 1, 31, 23, 59)]}
 
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'D')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'D')"] == [
-                util.to_timestamp(datetime(2020, 1, 31))
+                util.to_timestamp(date(2020, 1, 31))
             ]
 
         def test_table_day_bucket_edge_in_CST(self, util):
@@ -1492,7 +1490,7 @@ if os.name != "nt":
             view = table.view(expressions=["bucket(\"a\", 'D')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'D')"] == [
-                util.to_timestamp(datetime(2020, 1, 31))
+                util.to_timestamp(date(2020, 1, 31))
             ]
 
         def test_table_day_bucket_edge_in_PST(self, util):
@@ -1505,20 +1503,20 @@ if os.name != "nt":
             view = table.view(expressions=["bucket(\"a\", 'D')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'D')"] == [
-                util.to_timestamp(datetime(2020, 1, 31))
+                util.to_timestamp(date(2020, 1, 31))
             ]
 
         def test_table_week_bucket_edge_in_EST(self, util):
-            """Make sure edge cases are fixed for week_bucket - if a local
-            time converted to UTC is in the next day, the week_bucket
-            computation needs to be in local time."""
+            """`week_bucket` is computed in UTC and the resulting `date`
+            serializes to UTC midnight, so the host timezone must not shift
+            the bucket or its serialized value."""
             data = {"a": [datetime(2020, 2, 2, 23, 59)]}
 
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'W')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'W')"] == [
-                util.to_timestamp(datetime(2020, 1, 27))
+                util.to_timestamp(date(2020, 1, 27))
             ]
 
         def test_table_week_bucket_edge_in_CST(self, util):
@@ -1531,7 +1529,7 @@ if os.name != "nt":
             view = table.view(expressions=["bucket(\"a\", 'W')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'W')"] == [
-                util.to_timestamp(datetime(2020, 1, 27))
+                util.to_timestamp(date(2020, 1, 27))
             ]
 
         def test_table_week_bucket_edge_in_PST(self, util):
@@ -1544,7 +1542,7 @@ if os.name != "nt":
             view = table.view(expressions=["bucket(\"a\", 'W')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'W')"] == [
-                util.to_timestamp(datetime(2020, 1, 27))
+                util.to_timestamp(date(2020, 1, 27))
             ]
 
         def test_table_week_bucket_edge_flip_in_EST(self, util):
@@ -1555,7 +1553,7 @@ if os.name != "nt":
             view = table.view(expressions=["bucket(\"a\", 'W')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'W')"] == [
-                util.to_timestamp(datetime(2020, 2, 24))
+                util.to_timestamp(date(2020, 2, 24))
             ]
 
         def test_table_week_bucket_edge_flip_in_CST(self, util):
@@ -1567,7 +1565,7 @@ if os.name != "nt":
             view = table.view(expressions=["bucket(\"a\", 'W')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'W')"] == [
-                util.to_timestamp(datetime(2020, 2, 24))
+                util.to_timestamp(date(2020, 2, 24))
             ]
 
         def test_table_week_bucket_edge_flip_in_PST(self, util):
@@ -1579,20 +1577,20 @@ if os.name != "nt":
             view = table.view(expressions=["bucket(\"a\", 'W')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'W')"] == [
-                util.to_timestamp(datetime(2020, 2, 24))
+                util.to_timestamp(date(2020, 2, 24))
             ]
 
         def test_table_month_bucket_edge_in_EST(self, util):
-            """Make sure edge cases are fixed for month_bucket - if a local
-            time converted to UTC is in the next day, the month_bucket
-            computation needs to be in local time."""
+            """`month_bucket` is computed in UTC and the resulting `date`
+            serializes to UTC midnight, so the host timezone must not shift
+            the bucket or its serialized value."""
             data = {"a": [datetime(2020, 6, 30, 23, 59)]}
 
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'M')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'M')"] == [
-                util.to_timestamp(datetime(2020, 6, 1))
+                util.to_timestamp(date(2020, 6, 1))
             ]
 
         def test_table_month_bucket_edge_in_CST(self, util):
@@ -1605,7 +1603,7 @@ if os.name != "nt":
             view = table.view(expressions=["bucket(\"a\", 'M')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'M')"] == [
-                util.to_timestamp(datetime(2020, 6, 1))
+                util.to_timestamp(date(2020, 6, 1))
             ]
 
         def test_table_month_bucket_edge_in_PST(self, util):
@@ -1618,20 +1616,20 @@ if os.name != "nt":
             view = table.view(expressions=["bucket(\"a\", 'M')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'M')"] == [
-                util.to_timestamp(datetime(2020, 6, 1))
+                util.to_timestamp(date(2020, 6, 1))
             ]
 
         def test_table_year_bucket_edge_in_EST(self, util):
-            """Make sure edge cases are fixed for year_bucket - if a local
-            time converted to UTC is in the next day, the year_bucket
-            computation needs to be in local time."""
+            """`year_bucket` is computed in UTC and the resulting `date`
+            serializes to UTC midnight, so the host timezone must not shift
+            the bucket or its serialized value."""
             data = {"a": [datetime(2019, 12, 31, 23, 59)]}
 
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'Y')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'Y')"] == [
-                util.to_timestamp(datetime(2019, 1, 1))
+                util.to_timestamp(date(2019, 1, 1))
             ]
 
         def test_table_year_bucket_edge_in_CST(self, util):
@@ -1643,7 +1641,7 @@ if os.name != "nt":
             view = table.view(expressions=["bucket(\"a\", 'Y')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'Y')"] == [
-                util.to_timestamp(datetime(2019, 1, 1))
+                util.to_timestamp(date(2019, 1, 1))
             ]
 
         def test_table_year_bucket_edge_in_PST(self, util):
@@ -1655,7 +1653,7 @@ if os.name != "nt":
             view = table.view(expressions=["bucket(\"a\", 'Y')"])
             result = view.to_columns()
             assert result["bucket(\"a\", 'Y')"] == [
-                util.to_timestamp(datetime(2019, 1, 1))
+                util.to_timestamp(date(2019, 1, 1))
             ]
 
 
@@ -1670,18 +1668,18 @@ class TestTableDateTimePivots(object):
         assert view.to_columns() == {
             "__ROW_PATH__": [
                 [],
-                [util.to_timestamp(datetime(2020, 1, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 2, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 3, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 4, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 5, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 6, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 7, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 8, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 9, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 10, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 11, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 12, 15, 0, 0))],
+                [util.to_timestamp(date(2020, 1, 15))],
+                [util.to_timestamp(date(2020, 2, 15))],
+                [util.to_timestamp(date(2020, 3, 15))],
+                [util.to_timestamp(date(2020, 4, 15))],
+                [util.to_timestamp(date(2020, 5, 15))],
+                [util.to_timestamp(date(2020, 6, 15))],
+                [util.to_timestamp(date(2020, 7, 15))],
+                [util.to_timestamp(date(2020, 8, 15))],
+                [util.to_timestamp(date(2020, 9, 15))],
+                [util.to_timestamp(date(2020, 10, 15))],
+                [util.to_timestamp(date(2020, 11, 15))],
+                [util.to_timestamp(date(2020, 12, 15))],
             ],
             "a": [12, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
             "b": [78, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
@@ -1697,18 +1695,18 @@ class TestTableDateTimePivots(object):
         assert view.to_columns() == {
             "__ROW_PATH__": [
                 [],
-                [util.to_timestamp(datetime(2020, 1, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 2, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 3, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 4, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 5, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 6, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 7, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 8, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 9, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 10, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 11, 15, 0, 0))],
-                [util.to_timestamp(datetime(2020, 12, 15, 0, 0))],
+                [util.to_timestamp(date(2020, 1, 15))],
+                [util.to_timestamp(date(2020, 2, 15))],
+                [util.to_timestamp(date(2020, 3, 15))],
+                [util.to_timestamp(date(2020, 4, 15))],
+                [util.to_timestamp(date(2020, 5, 15))],
+                [util.to_timestamp(date(2020, 6, 15))],
+                [util.to_timestamp(date(2020, 7, 15))],
+                [util.to_timestamp(date(2020, 8, 15))],
+                [util.to_timestamp(date(2020, 9, 15))],
+                [util.to_timestamp(date(2020, 10, 15))],
+                [util.to_timestamp(date(2020, 11, 15))],
+                [util.to_timestamp(date(2020, 12, 15))],
             ],
             "index": [66, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
             "a": [12, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
@@ -1724,7 +1722,7 @@ class TestTableDateTimePivots(object):
         view = table.view(split_by=["a"])
         assert view.to_columns() == {
             "2020-01-15|a": [
-                util.to_timestamp(datetime(2020, 1, 15, 0, 0)),
+                util.to_timestamp(date(2020, 1, 15)),
                 None,
                 None,
                 None,
@@ -1753,7 +1751,7 @@ class TestTableDateTimePivots(object):
             ],
             "2020-02-15|a": [
                 None,
-                util.to_timestamp(datetime(2020, 2, 15, 0, 0)),
+                util.to_timestamp(date(2020, 2, 15)),
                 None,
                 None,
                 None,
@@ -1782,7 +1780,7 @@ class TestTableDateTimePivots(object):
             "2020-03-15|a": [
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 3, 15, 0, 0)),
+                util.to_timestamp(date(2020, 3, 15)),
                 None,
                 None,
                 None,
@@ -1811,7 +1809,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 4, 15, 0, 0)),
+                util.to_timestamp(date(2020, 4, 15)),
                 None,
                 None,
                 None,
@@ -1840,7 +1838,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 5, 15, 0, 0)),
+                util.to_timestamp(date(2020, 5, 15)),
                 None,
                 None,
                 None,
@@ -1869,7 +1867,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 6, 15, 0, 0)),
+                util.to_timestamp(date(2020, 6, 15)),
                 None,
                 None,
                 None,
@@ -1898,7 +1896,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 7, 15, 0, 0)),
+                util.to_timestamp(date(2020, 7, 15)),
                 None,
                 None,
                 None,
@@ -1927,7 +1925,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 8, 15, 0, 0)),
+                util.to_timestamp(date(2020, 8, 15)),
                 None,
                 None,
                 None,
@@ -1956,7 +1954,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 9, 15, 0, 0)),
+                util.to_timestamp(date(2020, 9, 15)),
                 None,
                 None,
                 None,
@@ -1985,7 +1983,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 10, 15, 0, 0)),
+                util.to_timestamp(date(2020, 10, 15)),
                 None,
                 None,
             ],
@@ -2014,7 +2012,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 11, 15, 0, 0)),
+                util.to_timestamp(date(2020, 11, 15)),
                 None,
             ],
             "2020-11-15|b": [
@@ -2043,7 +2041,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 12, 15, 0, 0)),
+                util.to_timestamp(date(2020, 12, 15)),
             ],
             "2020-12-15|b": [
                 None,
@@ -2071,7 +2069,7 @@ class TestTableDateTimePivots(object):
         print(f"XXXX: {view.to_columns()}")
         assert view.to_columns() == {
             "2020-01-15|a": [
-                util.to_timestamp(datetime(2020, 1, 15, 0, 0)),
+                util.to_timestamp(date(2020, 1, 15)),
                 None,
                 None,
                 None,
@@ -2100,7 +2098,7 @@ class TestTableDateTimePivots(object):
             ],
             "2020-02-15|a": [
                 None,
-                util.to_timestamp(datetime(2020, 2, 15, 0, 0)),
+                util.to_timestamp(date(2020, 2, 15)),
                 None,
                 None,
                 None,
@@ -2129,7 +2127,7 @@ class TestTableDateTimePivots(object):
             "2020-03-15|a": [
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 3, 15, 0, 0)),
+                util.to_timestamp(date(2020, 3, 15)),
                 None,
                 None,
                 None,
@@ -2158,7 +2156,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 4, 15, 0, 0)),
+                util.to_timestamp(date(2020, 4, 15)),
                 None,
                 None,
                 None,
@@ -2187,7 +2185,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 5, 15, 0, 0)),
+                util.to_timestamp(date(2020, 5, 15)),
                 None,
                 None,
                 None,
@@ -2216,7 +2214,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 6, 15, 0, 0)),
+                util.to_timestamp(date(2020, 6, 15)),
                 None,
                 None,
                 None,
@@ -2245,7 +2243,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 7, 15, 0, 0)),
+                util.to_timestamp(date(2020, 7, 15)),
                 None,
                 None,
                 None,
@@ -2274,7 +2272,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 8, 15, 0, 0)),
+                util.to_timestamp(date(2020, 8, 15)),
                 None,
                 None,
                 None,
@@ -2303,7 +2301,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 9, 15, 0, 0)),
+                util.to_timestamp(date(2020, 9, 15)),
                 None,
                 None,
                 None,
@@ -2332,7 +2330,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 10, 15, 0, 0)),
+                util.to_timestamp(date(2020, 10, 15)),
                 None,
                 None,
             ],
@@ -2361,7 +2359,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 11, 15, 0, 0)),
+                util.to_timestamp(date(2020, 11, 15)),
                 None,
             ],
             "2020-11-15|b": [
@@ -2390,7 +2388,7 @@ class TestTableDateTimePivots(object):
                 None,
                 None,
                 None,
-                util.to_timestamp(datetime(2020, 12, 15, 0, 0)),
+                util.to_timestamp(date(2020, 12, 15)),
             ],
             "2020-12-15|b": [
                 None,
@@ -2407,3 +2405,140 @@ class TestTableDateTimePivots(object):
                 12,
             ],
         }
+
+
+if hasattr(time, "tzset"):
+
+    class TestTableDateTimeUTC(object):
+        """The engine is timezone-agnostic: `date` values are calendar days
+        that serialize to epoch ms at *UTC* midnight (matching Arrow `date32`
+        day arithmetic), naive datetime strings parse as UTC, and datetime
+        expression functions compute in UTC. None of these results may vary
+        with the host process timezone — the same table must serialize
+        identically on a server in Amsterdam, Tokyo, or New York, and a
+        UTC-pinned client renderer must recover the stored calendar day.
+
+        https://github.com/perspective-dev/perspective/issues/3106
+        """
+
+        def teardown_method(self):
+            os.environ["TZ"] = "UTC"
+            time.tzset()
+
+        @mark.parametrize(
+            "timezone_name",
+            ["UTC", "Europe/Amsterdam", "Asia/Tokyo", "US/Pacific"],
+        )
+        def test_table_date_serializes_to_utc_midnight(self, timezone_name):
+            """Issue #3106: under `mktime`-based serialization, an Amsterdam
+            host serialized 2024-01-01 as 2023-12-31T23:00:00Z, which a UTC
+            renderer displays as the previous day."""
+            os.environ["TZ"] = timezone_name
+            time.tzset()
+
+            table = Table({"a": "date"})
+            table.update({"a": ["2024-01-01"]})
+            assert table.view().to_columns()["a"] == [1704067200000]
+
+        @mark.parametrize(
+            "timezone_name",
+            ["UTC", "Europe/Amsterdam", "Asia/Tokyo", "US/Pacific"],
+        )
+        def test_table_date_formatted_string_is_calendar_day(
+            self, timezone_name
+        ):
+            """The formatted (stringified) output path must print the stored
+            calendar day, not the UTC rendering of a local-midnight
+            instant."""
+            os.environ["TZ"] = timezone_name
+            time.tzset()
+
+            table = Table({"a": "date"})
+            table.update({"a": ["2024-01-01"]})
+            assert (
+                table.view().to_columns_string(formatted=True)
+                == '{"a":["2024-01-01"]}'
+            )
+
+        @mark.parametrize(
+            "timezone_name",
+            ["UTC", "Europe/Amsterdam", "Asia/Tokyo", "US/Pacific"],
+        )
+        def test_table_date_epoch_ms_round_trips(self, timezone_name):
+            """Epoch-ms `date` input is UTC midnight, the same convention as
+            serialization; `localtime`-based parsing read a UTC date as the
+            previous day on hosts west of UTC."""
+            os.environ["TZ"] = timezone_name
+            time.tzset()
+
+            table = Table({"a": "date"})
+            table.update({"a": [1704067200000]})
+            assert table.view().to_columns()["a"] == [1704067200000]
+
+        def test_table_date_group_by_row_path_is_utc_midnight(self, util):
+            os.environ["TZ"] = "Europe/Amsterdam"
+            time.tzset()
+
+            table = Table({"a": [date(2024, 1, 1)], "b": [1]})
+            view = table.view(group_by=["a"])
+            assert view.to_columns()["__ROW_PATH__"] == [
+                [],
+                [util.to_timestamp(date(2024, 1, 1))],
+            ]
+
+        def test_table_day_bucket_edge_in_JST(self, util):
+            """23:59 UTC is already the next day in Asia/Tokyo — the bucket
+            must stay on the UTC calendar day."""
+            os.environ["TZ"] = "Asia/Tokyo"
+            time.tzset()
+
+            data = {"a": [datetime(2020, 1, 31, 23, 59)]}
+            table = Table(data)
+            view = table.view(expressions=["bucket(\"a\", 'D')"])
+            result = view.to_columns()
+            assert result["bucket(\"a\", 'D')"] == [
+                util.to_timestamp(date(2020, 1, 31))
+            ]
+
+        def test_table_day_of_week_edge_in_JST(self):
+            os.environ["TZ"] = "Asia/Tokyo"
+            time.tzset()
+
+            data = {"a": [datetime(2020, 1, 31, 23, 59)]}
+            table = Table(data)
+            view = table.view(expressions=['day_of_week("a")'])
+            result = view.to_columns()
+            assert result['day_of_week("a")'] == ["6 Friday"]
+
+        def test_table_month_of_year_edge_in_JST(self):
+            os.environ["TZ"] = "Asia/Tokyo"
+            time.tzset()
+
+            data = {"a": [datetime(2020, 1, 31, 23, 59)]}
+            table = Table(data)
+            view = table.view(expressions=['month_of_year("a")'])
+            result = view.to_columns()
+            assert result['month_of_year("a")'] == ["01 January"]
+
+        def test_table_hour_of_day_edge_in_JST(self):
+            os.environ["TZ"] = "Asia/Tokyo"
+            time.tzset()
+
+            data = {"a": [datetime(2020, 1, 31, 23, 59)]}
+            table = Table(data)
+            view = table.view(expressions=['hour_of_day("a")'])
+            result = view.to_columns()
+            assert result['hour_of_day("a")'] == [23]
+
+        def test_table_non_iso_datetime_string_parses_as_utc(self, util):
+            """The non-ISO fallback datetime parser must also interpret naive
+            strings as UTC, as documented — `mktime`-based parsing applied
+            the host timezone."""
+            os.environ["TZ"] = "Europe/Amsterdam"
+            time.tzset()
+
+            table = Table({"a": "datetime"})
+            table.update({"a": ["01/31/2020 23:59"]})
+            assert table.view().to_columns()["a"] == [
+                util.to_timestamp(UTC.localize(datetime(2020, 1, 31, 23, 59)))
+            ]

--- a/rust/perspective-server/cpp/perspective/src/cpp/computed_function.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/computed_function.cpp
@@ -977,19 +977,12 @@ hour_of_day::operator()(t_parameter_list parameters) {
     val.set(temp_scalar);
 
     if (val.get_dtype() == DTYPE_TIME) {
-        // Convert the int64 to a milliseconds duration timestamp
-        std::chrono::milliseconds timestamp(val.to_int64());
-
-        // Convert the timestamp to a `sys_time` (alias for `time_point`)
-        date::sys_time<std::chrono::milliseconds> ts(timestamp);
-
-        // Use localtime so that the hour of day is consistent with all
-        // output datetimes, which are in local time
-        std::time_t temp = std::chrono::system_clock::to_time_t(ts);
-        std::tm* t = std::localtime(&temp);
+        // Break down the UTC timestamp in UTC — the host timezone must not
+        // affect engine results (native and WASM builds must agree)
+        std::tm t = gmtime_from_epoch_ms(val.to_int64());
 
         // Get the hour from the resulting `std::tm`
-        rval.set(static_cast<double>(t->tm_hour));
+        rval.set(static_cast<double>(t.tm_hour));
     } else {
         // Hour of day for date column is always 0
         rval.set(0.0);
@@ -1069,19 +1062,12 @@ day_of_week::operator()(t_parameter_list parameters) {
     std::string result;
 
     if (val.get_dtype() == DTYPE_TIME) {
-        // Convert the int64 to a milliseconds duration timestamp
-        std::chrono::milliseconds timestamp(val.to_int64());
-
-        // Convert the timestamp to a `sys_time` (alias for `time_point`)
-        date::sys_time<std::chrono::milliseconds> ts(timestamp);
-
-        // Use localtime so that the hour of day is consistent with all
-        // output datetimes, which are in local time
-        std::time_t temp = std::chrono::system_clock::to_time_t(ts);
-        std::tm* t = std::localtime(&temp);
+        // Break down the UTC timestamp in UTC — the host timezone must not
+        // affect engine results (native and WASM builds must agree)
+        std::tm t = gmtime_from_epoch_ms(val.to_int64());
 
         // Get the weekday from the resulting `std::tm`
-        result = days_of_week[t->tm_wday];
+        result = days_of_week[t.tm_wday];
     } else {
         // Retrieve the `t_date` struct from the scalar
         t_date date_val = val.get<t_date>();
@@ -1153,22 +1139,12 @@ month_of_year::operator()(t_parameter_list parameters) {
     std::string result;
 
     if (val.get_dtype() == DTYPE_TIME) {
-        // Convert the int64 to a milliseconds duration timestamp
-        std::chrono::milliseconds timestamp(val.to_int64());
-
-        // Convert the timestamp to a `sys_time` (alias for `time_point`)
-        date::sys_time<std::chrono::milliseconds> ts(timestamp);
-
-        // Use localtime so that the hour of day is consistent with all
-        // output datetimes, which are in local time
-        std::time_t temp = std::chrono::system_clock::to_time_t(ts);
-        std::tm* t = std::localtime(&temp);
-
-        // Get the month from the resulting `std::tm`
-        auto month = t->tm_mon;
+        // Break down the UTC timestamp in UTC — the host timezone must not
+        // affect engine results (native and WASM builds must agree)
+        std::tm t = gmtime_from_epoch_ms(val.to_int64());
 
         // Get the month string and write into the output column
-        result = months_of_year[month];
+        result = months_of_year[t.tm_mon];
     } else {
         t_date date_val = val.get<t_date>();
 
@@ -1436,28 +1412,10 @@ void
 _day_bucket(t_tscalar& val, t_tscalar& rval) {
     switch (val.get_dtype()) {
         case DTYPE_TIME: {
-            // Convert the int64 to a milliseconds duration timestamp
-            std::chrono::milliseconds ms_timestamp(val.to_int64());
-
-            // Convert the timestamp to a `sys_time` (alias for
-            // `time_point`)
-            date::sys_time<std::chrono::milliseconds> ts(ms_timestamp);
-
-            // Use localtime so that the day of week is consistent with all
-            // output datetimes, which are in local time
-            std::time_t temp = std::chrono::system_clock::to_time_t(ts);
-
-            // Convert to a std::tm
-            std::tm* t = std::localtime(&temp);
-
-            // Get the year and create a new `t_date`
-            auto year = static_cast<std::int32_t>(t->tm_year + 1900);
-
-            // Month in `t_date` is [0-11]
-            std::int32_t month = static_cast<std::uint32_t>(t->tm_mon);
-            auto day = static_cast<std::uint32_t>(t->tm_mday);
-
-            rval.set(t_date(year, month, day));
+            // The UTC calendar day containing the UTC timestamp — the host
+            // timezone must not affect engine results (native and WASM
+            // builds must agree)
+            rval.set(t_date::from_epoch_ms(val.to_int64()));
         } break;
         case DTYPE_DATE:
         default: {
@@ -1503,24 +1461,15 @@ _week_bucket(t_tscalar& val, t_tscalar& rval) {
             rval.set(new_date);
         } break;
         case DTYPE_TIME: {
-            // Convert the int64 to a milliseconds duration timestamp
-            std::chrono::milliseconds timestamp(val.to_int64());
-
-            // Convert the timestamp to a `sys_time` (alias for
-            // `time_point`)
-            date::sys_time<std::chrono::milliseconds> ts(timestamp);
-
-            // Convert the timestamp to local time
-            std::time_t temp = std::chrono::system_clock::to_time_t(ts);
-            std::tm* t = std::localtime(&temp);
-
-            // Take the ymd from the `tm`, now in local time, and create a
+            // Take the ymd of the UTC timestamp in UTC — the host timezone
+            // must not affect engine results — and create a
             // date::year_month_day.
-            date::year year{1900 + t->tm_year};
+            std::tm t = gmtime_from_epoch_ms(val.to_int64());
+            date::year year{1900 + t.tm_year};
 
             // date::month is [1-12], whereas `std::tm::tm_mon` is [0-11]
-            date::month month{static_cast<std::uint32_t>(t->tm_mon) + 1};
-            date::day day{static_cast<std::uint32_t>(t->tm_mday)};
+            date::month month{static_cast<std::uint32_t>(t.tm_mon) + 1};
+            date::day day{static_cast<std::uint32_t>(t.tm_mday)};
             date::year_month_day ymd(year, month, day);
 
             // Convert to a `sys_days` representing no. of days since epoch
@@ -1560,21 +1509,13 @@ _month_bucket(t_tscalar& val, t_tscalar& rval, t_uindex multiplicity) {
             rval.set(t_date(date_val.year(), out_month, 1));
         } break;
         case DTYPE_TIME: {
-            // Convert the int64 to a milliseconds duration
-            // timestamp
-            std::chrono::milliseconds ms_timestamp(val.to_int64());
-
-            // Convert the timestamp to a `sys_time` (alias for
-            // `time_point`)
-            date::sys_time<std::chrono::milliseconds> ts(ms_timestamp);
-
-            // Convert the timestamp to local time
-            std::time_t temp = std::chrono::system_clock::to_time_t(ts);
-            std::tm* t = std::localtime(&temp);
+            // Break down the UTC timestamp in UTC — the host timezone must
+            // not affect engine results
+            std::tm t = gmtime_from_epoch_ms(val.to_int64());
 
             // Use the `tm` to create the `t_date`
-            auto year = static_cast<std::int32_t>(t->tm_year + 1900);
-            std::int32_t month = static_cast<std::uint32_t>(t->tm_mon);
+            auto year = static_cast<std::int32_t>(t.tm_year + 1900);
+            std::int32_t month = static_cast<std::uint32_t>(t.tm_mon);
             if (multiplicity != 1) {
                 month = floor(static_cast<double>(month) / multiplicity)
                     * multiplicity;
@@ -1599,19 +1540,12 @@ _year_bucket(t_tscalar& val, t_tscalar& rval, t_uindex multiplicity) {
             ));
         } break;
         case DTYPE_TIME: {
-            // Convert the int64 to a milliseconds duration timestamp
-            std::chrono::milliseconds ms_timestamp(val.to_int64());
-
-            // Convert the timestamp to a `sys_time` (alias for
-            // `time_point`)
-            date::sys_time<std::chrono::milliseconds> ts(ms_timestamp);
-
-            // Convert the timestamp to local time
-            std::time_t temp = std::chrono::system_clock::to_time_t(ts);
-            std::tm* t = std::localtime(&temp);
+            // Break down the UTC timestamp in UTC — the host timezone must
+            // not affect engine results
+            std::tm t = gmtime_from_epoch_ms(val.to_int64());
 
             // Use the `tm` to create the `t_date`
-            auto year = static_cast<std::int32_t>(t->tm_year + 1900);
+            auto year = static_cast<std::int32_t>(t.tm_year + 1900);
             if (multiplicity != 1) {
                 year = floor(static_cast<double>(year) / multiplicity)
                     * multiplicity;
@@ -1639,27 +1573,13 @@ today() {
     t_tscalar rval;
 
     auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch()
-    );
+                   std::chrono::system_clock::now().time_since_epoch()
+    )
+                   .count();
 
-    // Convert the timestamp to a `sys_time` (alias for `time_point`)
-    date::sys_time<std::chrono::milliseconds> ts(now);
-
-    // Use localtime so that the day of week is consistent with all output
-    // datetimes, which are in local time
-    std::time_t temp = std::chrono::system_clock::to_time_t(ts);
-
-    // Convert to a std::tm
-    std::tm* t = std::localtime(&temp);
-
-    // Get the year and create a new `t_date`
-    auto year = static_cast<std::int32_t>(t->tm_year + 1900);
-
-    // Month in `t_date` is [0-11]
-    std::int32_t month = static_cast<std::uint32_t>(t->tm_mon);
-    auto day = static_cast<std::uint32_t>(t->tm_mday);
-
-    rval.set(t_date(year, month, day));
+    // The current UTC calendar day, consistent with `bucket("x", 'D')` of
+    // `now()` — the host timezone must not affect engine results
+    rval.set(t_date::from_epoch_ms(now));
     return rval;
 }
 

--- a/rust/perspective-server/cpp/perspective/src/cpp/date.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/date.cpp
@@ -12,6 +12,7 @@
 
 #include <perspective/first.h>
 #include <perspective/date.h>
+#include <perspective/time.h>
 
 namespace perspective {
 
@@ -72,19 +73,20 @@ t_date::consecutive_day_idx() const {
         + CUMULATIVE_DAYS[leap_selector][m - 1];
 }
 
-std::tm
-t_date::get_tm() const {
-    std::tm rval;
+std::int64_t
+t_date::as_epoch_ms() const {
+    // `to_gmtime` months are [1-12], `t_date` months are [0-11]
+    return to_gmtime(year(), month() + 1, day(), 0, 0, 0) * 1000;
+}
 
-    rval.tm_year = year() - 1900; // tm years are since 1900
-    rval.tm_mon = month();        // tm months from 0, so no need to decrement
-    rval.tm_mday = day();
-    rval.tm_hour = 0;
-    rval.tm_min = 0;
-    rval.tm_sec = 0;
-    rval.tm_isdst = -1; // let std::mktime decide whether DST is in effect
-
-    return rval;
+t_date
+t_date::from_epoch_ms(std::int64_t ms) {
+    std::tm t = gmtime_from_epoch_ms(ms);
+    return {
+        static_cast<std::int16_t>(t.tm_year + 1900),
+        static_cast<std::int8_t>(t.tm_mon),
+        static_cast<std::int8_t>(t.tm_mday)
+    };
 }
 
 t_date

--- a/rust/perspective-server/cpp/perspective/src/cpp/scalar.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/scalar.cpp
@@ -1109,13 +1109,8 @@ t_tscalar::to_string(bool for_expr) const {
 
                 return ss.str();
             }
-            t_date date_val = get<t_date>();
-            tm t = date_val.get_tm();
-            time_t epoch_delta = mktime(&t);
-            std::chrono::milliseconds timestamp(epoch_delta * 1000);
-            date::sys_time<std::chrono::milliseconds> ts(timestamp);
-            return date::format("%F", ts);
 
+            return get<t_date>().str();
         } break;
         case DTYPE_BOOL: {
             ss << std::boolalpha << get<bool>();
@@ -1130,9 +1125,8 @@ t_tscalar::to_string(bool for_expr) const {
             return ss.str();
         } break;
         case DTYPE_TIME: {
-            // Convert a millisecond UTC timestamp to a formatted datestring in
-            // local time, as all datetimes exported to the user happens in
-            // local time and not UTC.
+            // Format a millisecond UTC timestamp as a UTC datestring;
+            // localization is the display layer's job.
             std::chrono::milliseconds timestamp(to_int64());
             date::sys_time<std::chrono::milliseconds> ts(timestamp);
             return date::format("%F %T", ts);

--- a/rust/perspective-server/cpp/perspective/src/cpp/table.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/table.cpp
@@ -635,8 +635,7 @@ json_into(const rapidjson::Value& value) {
                 PSP_COMPLAIN_AND_ABORT("Could not coerce to date");
             }
         } else if (value.IsInt64()) {
-            auto tt = time_t(value.GetInt64() / 1000);
-            tm = *localtime(&tt);
+            return t_date::from_epoch_ms(value.GetInt64());
         } else {
             PSP_COMPLAIN_AND_ABORT("Could not coerce to date");
         }

--- a/rust/perspective-server/cpp/perspective/src/cpp/time.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/time.cpp
@@ -88,7 +88,7 @@ isleap(long int year) {
 }
 
 std::int32_t
-t_time::gmtime(struct tm& out, std::int64_t secs, std::int32_t offset) const {
+t_time::gmtime(struct tm& out, std::int64_t secs, std::int32_t offset) {
     std::int64_t days;
     std::int64_t rem;
     std::int64_t y;
@@ -234,6 +234,18 @@ to_gmtime(
     std::int64_t days = ymd_to_ord(year, month, day) - EPOCH_ORD;
     std::int64_t res = ((days * 24 + hour) * 60 + min) * 60 + sec;
     return static_cast<std::int64_t>(res);
+}
+
+std::tm
+gmtime_from_epoch_ms(std::int64_t ms) {
+    std::tm out{};
+    std::int64_t secs = ms / 1000;
+    if (ms % 1000 < 0) {
+        secs -= 1;
+    }
+
+    t_time::gmtime(out, secs, 0);
+    return out;
 }
 
 t_time&

--- a/rust/perspective-server/cpp/perspective/src/cpp/utils.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/utils.cpp
@@ -18,6 +18,7 @@
 #include <perspective/raw_types.h>
 #include <perspective/base.h>
 #include <perspective/utils.h>
+#include <perspective/time.h>
 #include <string>
 #include <chrono>
 #include <sstream>
@@ -97,10 +98,17 @@ parse_date_time(
                             << tm.tm_min << ":" << tm.tm_sec
         );
 
-        std::tm tm_cp = tm;
-        // wtf... std::mktime normalizes the input struct just to get the time
-        // out.
-        tp = std::chrono::system_clock::from_time_t(std::mktime(&tm_cp));
+        // Naive datetime strings are documented to be UTC — `std::mktime`
+        // would interpret the parsed civil time in the host timezone.
+        tp = std::chrono::system_clock::from_time_t(to_gmtime(
+            tm.tm_year + 1900,
+            tm.tm_mon + 1,
+            tm.tm_mday,
+            tm.tm_hour,
+            tm.tm_min,
+            tm.tm_sec
+        ));
+
         if (!ss.eof() && ss.peek() == '.') {
             ss.ignore();
             std::int32_t ms;

--- a/rust/perspective-server/cpp/perspective/src/cpp/view.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/view.cpp
@@ -1858,10 +1858,7 @@ write_scalar(
             if (is_formatted) {
                 writer.String(scalar.to_string().c_str());
             } else {
-                t_date date_val = scalar.get<t_date>();
-                tm t = date_val.get_tm();
-                time_t epoch_delta = mktime(&t);
-                writer.Int64(epoch_delta * 1000);
+                writer.Int64(scalar.get<t_date>().as_epoch_ms());
             }
             break;
         }

--- a/rust/perspective-server/cpp/perspective/src/include/perspective/date.h
+++ b/rust/perspective-server/cpp/perspective/src/include/perspective/date.h
@@ -79,12 +79,22 @@ public:
     std::int32_t consecutive_day_idx() const;
 
     /**
-     * @brief Return an `std::tm` object. `tm_hour`, `tm_min`, and `tm_sec` are
-     * set to 0.
+     * @brief Milliseconds since the Unix epoch at *UTC* midnight of this
+     * calendar date. This is the serialization convention for `date` values
+     * (matching Arrow's `date32` day arithmetic) — a `t_date` is a timezone-
+     * agnostic calendar day, so the host timezone must never be consulted.
      *
-     * @return std::tm
+     * @return std::int64_t
      */
-    std::tm get_tm() const;
+    std::int64_t as_epoch_ms() const;
+
+    /**
+     * @brief Inverse of `as_epoch_ms`: the UTC calendar date containing
+     * epoch `ms`.
+     *
+     * @return t_date
+     */
+    static t_date from_epoch_ms(std::int64_t ms);
 
     friend bool operator<(const t_date& a, const t_date& b);
     friend bool operator<=(const t_date& a, const t_date& b);

--- a/rust/perspective-server/cpp/perspective/src/include/perspective/time.h
+++ b/rust/perspective-server/cpp/perspective/src/include/perspective/time.h
@@ -66,6 +66,8 @@ std::int64_t to_gmtime(
     std::int32_t sec
 );
 
+std::tm gmtime_from_epoch_ms(std::int64_t ms);
+
 // Interal details: m_storage stores "microseconds since the
 // epoch-defined-in-the-class".
 // In terms of (non-tm based) inputs/outputs, t_time
@@ -113,8 +115,8 @@ public:
      */
     std::tm get_tm() const;
 
-    std::int32_t
-    gmtime(struct tm& out, std::int64_t secs, std::int32_t offset) const;
+    static std::int32_t
+    gmtime(struct tm& out, std::int64_t secs, std::int32_t offset);
 
     std::int32_t year(const struct tm& t) const;
     std::int32_t month(const struct tm& t) const;

--- a/tools/test/playwright.config.ts
+++ b/tools/test/playwright.config.ts
@@ -128,10 +128,6 @@ const NODE_PACKAGES = [
         packageName: "client",
         testDir: "rust/perspective-js/test/js",
     },
-    {
-        packageName: "client-tz",
-        testDir: "rust/perspective-js/test/tz",
-    },
 ];
 
 const BROWSER_AND_PYTHON_PACKAGES = [


### PR DESCRIPTION
This PR fixes 11 `date` encoding inconsistencies that used local midnight instead of UTC across the C++ codebase, and adds tests.