### PR TITLE
fix(datagrid): restore persisted column widths

### DIFF
--- a/packages/viewer-datagrid/src/ts/custom_elements/datagrid.ts
+++ b/packages/viewer-datagrid/src/ts/custom_elements/datagrid.ts
@@ -165,6 +165,7 @@ export class HTMLPerspectiveViewerDatagridPluginElement
 
         return {
             fields,
+            passthrough_keys: ["columns"],
         };
     }
 

--- a/packages/viewer-datagrid/src/ts/model/column_overrides.ts
+++ b/packages/viewer-datagrid/src/ts/model/column_overrides.ts
@@ -34,12 +34,12 @@ export function restore_column_size_overrides(
     old_sizes: ColumnOverrides,
     cache = false,
 ): void {
-    if (!this._initialized) {
-        return;
-    }
-
     if (cache) {
         this._cached_column_sizes = old_sizes;
+    }
+
+    if (!this._initialized) {
+        return;
     }
 
     const regular_table = this.regular_table as RegularTableWithOverrides;

--- a/packages/viewer-datagrid/src/ts/plugin/column_config_schema.ts
+++ b/packages/viewer-datagrid/src/ts/plugin/column_config_schema.ts
@@ -22,6 +22,7 @@ type ControlSpec = Record<string, unknown> & { kind: string };
 
 export interface ColumnConfigSchema {
     fields: ControlSpec[];
+    passthrough_keys?: string[];
 }
 
 /**

--- a/packages/viewer-datagrid/src/ts/plugin/draw.ts
+++ b/packages/viewer-datagrid/src/ts/plugin/draw.ts
@@ -62,6 +62,9 @@ export async function draw(
 
     restore_column_size_overrides.call(this, old_sizes);
     await drawPromise;
+    if (Object.keys(old_sizes).length > 0) {
+        restore_column_size_overrides.call(this, old_sizes);
+    }
 
     this._toolbar?.classList.toggle(
         "aggregated",

--- a/packages/viewer-datagrid/test/js/column_settings.spec.ts
+++ b/packages/viewer-datagrid/test/js/column_settings.spec.ts
@@ -65,6 +65,39 @@ test.describe("Datagrid Column Styles", function () {
             },
         });
     });
+
+    test("First restore applies and preserves column width overrides", async function ({
+        page,
+    }) {
+        const result = await page.evaluate(async () => {
+            const viewer = document.querySelector("perspective-viewer")!;
+            await viewer.restore({
+                plugin: "Datagrid",
+                columns: ["Row ID", "Sales"],
+                plugin_config: {
+                    columns: {
+                        Sales: { column_size_override: 311.1875 },
+                    },
+                },
+            });
+
+            const plugin = document.querySelector(
+                "perspective-viewer-datagrid",
+            ) as any;
+            const index = plugin.model._column_paths.indexOf("Sales");
+            const widths = plugin.regular_table.saveColumnSizes();
+
+            return {
+                config: (await viewer.save()).plugin_config,
+                width: widths[index],
+            };
+        });
+
+        expect(result.config.columns).toEqual({
+            Sales: { column_size_override: 311.1875 },
+        });
+        expect(result.width).toBe(311.1875);
+    });
 });
 
 const runTests = (title: string, beforeEachAndLocalTests: () => void) => {

--- a/rust/perspective-viewer/src/rust/config/column_config_schema.rs
+++ b/rust/perspective-viewer/src/rust/config/column_config_schema.rs
@@ -30,6 +30,11 @@ use super::{KeyValueOpts, NumberSeriesStyleDefaultConfig};
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ColumnConfigSchema {
     pub fields: Vec<ControlSpec>,
+
+    /// Plugin-owned keys that are persisted and passed to `restore()`, but do
+    /// not have a viewer-rendered settings control.
+    #[serde(default)]
+    pub passthrough_keys: Vec<String>,
 }
 
 impl ColumnConfigSchema {
@@ -45,6 +50,8 @@ impl ColumnConfigSchema {
                 out.insert(k.to_string());
             }
         }
+
+        out.extend(self.passthrough_keys.iter().cloned());
         out
     }
 }

--- a/rust/perspective-viewer/src/rust/queries/plugin_column_styles.rs
+++ b/rust/perspective-viewer/src/rust/queries/plugin_column_styles.rs
@@ -73,7 +73,10 @@ pub fn get_column_config_schema(
     let view_type = if let Some(x) = metadata.get_column_view_type(column_name) {
         x
     } else {
-        return Ok(ColumnConfigSchema { fields: vec![] });
+        return Ok(ColumnConfigSchema {
+            fields: vec![],
+            ..Default::default()
+        });
     };
 
     // Route through serde_json so maps serialize as plain JS objects

--- a/rust/perspective-viewer/src/rust/renderer/plugin_config.rs
+++ b/rust/perspective-viewer/src/rust/renderer/plugin_config.rs
@@ -332,7 +332,10 @@ impl Renderer {
             return Err(JsValue::from("view_schema not initialized").into());
         }
         let Some(view_type) = session.metadata().get_column_view_type(column_name) else {
-            return Ok(ColumnConfigSchema { fields: vec![] });
+            return Ok(ColumnConfigSchema {
+                fields: vec![],
+                ..Default::default()
+            });
         };
 
         let current_js = JsValue::from_serde_ext(&current_value).unwrap_or(JsValue::NULL);


### PR DESCRIPTION
## Description

On the first Datagrid restore, saved column widths could be discarded in two places: the viewer schema filtered out the plugin-owned `columns` key, and the width restore could run before the plugin and `regular-table` had finished their initial draw.

This change:

- declares `columns` as passthrough plugin config so it survives schema filtering
- caches width overrides received before Datagrid initialization
- reapplies saved widths after the initial `regular-table` draw completes
- adds a regression test that verifies both the rendered width override and the subsequently saved config

Fixes #3163.

## Validation

- `PACKAGE=viewer-datagrid pnpm run lint`
- `pnpm --filter @perspective-dev/metadata run build`
- `pnpm --filter @perspective-dev/server run build`
- `pnpm --filter @perspective-dev/client run build`
- `pnpm --filter @perspective-dev/viewer run build`
- `pnpm --filter @perspective-dev/viewer-datagrid run build`
- `PACKAGE=viewer-datagrid pnpm exec playwright test --config=tools/test/playwright.config.ts packages/viewer-datagrid/test/js/column_settings.spec.ts --grep=First` (1 passed)
- `git diff --check`

Documentation is not applicable because this fixes existing persistence behavior and does not add a public API.

## AI assistance

I used OpenAI Codex to inspect the codebase, assist with the implementation and regression test, and run and review the validation steps. I reviewed the final diff and test results myself.