### PR TITLE
Better tooltips and configuration groups

### DIFF
--- a/examples/cdn/package.json
+++ b/examples/cdn/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "cdn",
+    "private": true,
+    "version": "5.3.0",
+    "description": "A bundler-free example app which loads `@perspective-dev/viewer` from `<script type=\"module\">` tags.",
+    "type": "module",
+    "scripts": {
+        "start": "node server.mjs"
+    },
+    "keywords": [],
+    "license": "Apache-2.0",
+    "dependencies": {
+        "@perspective-dev/client": "workspace:",
+        "@perspective-dev/server": "workspace:",
+        "@perspective-dev/viewer": "workspace:",
+        "@perspective-dev/viewer-charts": "workspace:",
+        "@perspective-dev/viewer-datagrid": "workspace:",
+        "superstore-arrow": "catalog:"
+    }
+}

--- a/examples/cdn/server.mjs
+++ b/examples/cdn/server.mjs
@@ -1,0 +1,19 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { WebSocketServer } from "@perspective-dev/client";
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+new WebSocketServer({ assets: [__dirname, "dist", "../../"] });

--- a/packages/viewer-charts/src/css/perspective-viewer-charts.css
+++ b/packages/viewer-charts/src/css/perspective-viewer-charts.css
@@ -89,7 +89,6 @@
     border-radius: 3px;
     padding: 3px;
     overflow-y: auto;
-    white-space: pre;
     z-index: 10;
     line-height: 16px;
 }

--- a/packages/viewer-charts/src/ts/axis/bar-axis.ts
+++ b/packages/viewer-charts/src/ts/axis/bar-axis.ts
@@ -12,7 +12,7 @@
 
 import type { Canvas2D, Context2D } from "../charts/canvas-types";
 import { PlotLayout } from "../layout/plot-layout";
-import { formatTickValue, formatDateTickValue } from "../layout/ticks";
+import { stepTickFormatter } from "../layout/ticks";
 import { initCanvas } from "./canvas";
 import {
     renderCategoricalXTicks,
@@ -37,12 +37,7 @@ function tickFormatter(
         return override;
     }
 
-    if (!domain.isDate) {
-        return formatTickValue;
-    }
-
-    const step = ticks.length > 1 ? ticks[1] - ticks[0] : 0;
-    return (v: number) => formatDateTickValue(v, step);
+    return stepTickFormatter(domain.isDate, ticks);
 }
 
 /**

--- a/packages/viewer-charts/src/ts/axis/numeric-axis.ts
+++ b/packages/viewer-charts/src/ts/axis/numeric-axis.ts
@@ -12,11 +12,7 @@
 
 import type { Canvas2D, Context2D } from "../charts/canvas-types";
 import { PlotLayout, type PlotRect } from "../layout/plot-layout";
-import {
-    computeNiceTicks,
-    formatTickValue,
-    formatDateTickValue,
-} from "../layout/ticks";
+import { computeNiceTicks, stepTickFormatter } from "../layout/ticks";
 import { getScaledContext } from "./canvas";
 import {
     drawGridlinesX,
@@ -81,10 +77,7 @@ function tickFmt(
         return override;
     }
 
-    const step = ticks.length > 1 ? ticks[1] - ticks[0] : 0;
-    return domain.isDate
-        ? (v: number) => formatDateTickValue(v, step)
-        : formatTickValue;
+    return stepTickFormatter(domain.isDate, ticks);
 }
 
 /**

--- a/packages/viewer-charts/src/ts/charts/candlestick/candlestick-interact.ts
+++ b/packages/viewer-charts/src/ts/charts/candlestick/candlestick-interact.ts
@@ -12,6 +12,7 @@
 
 import type { CandlestickChart } from "./candlestick";
 import { renderCandlestickChromeOverlay } from "./candlestick-render";
+import { tooltipStyleOf } from "../../interaction/tooltip-grid";
 
 /**
  * Pixels of horizontal slack around the wick centerline so narrow
@@ -163,24 +164,24 @@ export function showCandlestickPinnedTooltip(
         return;
     }
 
-    const lines = buildCandlestickTooltipLines(chart, idx);
-    if (lines.length === 0) {
+    const grid = buildCandlestickTooltipLines(chart, idx);
+    if (grid.length === 0) {
         return;
     }
 
     const xCenter = candles.xCenter[idx];
     const yMid = (candles.high[idx] + candles.low[idx]) / 2;
     const pos = chart._lastLayout.dataToPixel(xCenter, yMid);
-
-    // CSS bounds come from the chart's own layout, which is populated
-    // by the render path regardless of where the chart runs.
     const cssWidth = chart._lastLayout.cssWidth;
     const cssHeight = chart._lastLayout.cssHeight;
 
-    chart._tooltip.pin(lines, pos, { cssWidth, cssHeight });
+    chart._tooltip.pin(
+        grid,
+        pos,
+        { cssWidth, cssHeight },
+        tooltipStyleOf(chart._pluginConfig),
+    );
 
-    // Pinning hides the inline hover tooltip but does not change the
-    // WebGL pass — only the chrome overlay needs to redraw.
     chart._hoveredIdx = -1;
     renderCandlestickChromeOverlay(chart);
 }
@@ -190,19 +191,14 @@ export function dismissCandlestickPinnedTooltip(chart: CandlestickChart): void {
     chart._pinnedIdx = -1;
 }
 
-/**
- * Build tooltip lines for candle at index `idx` in the columnar
- * storage. Indexed access avoids materializing a `CandleRecord` POJO
- * on the hot tooltip path.
- */
 export function buildCandlestickTooltipLines(
     chart: CandlestickChart,
     idx: number,
-): string[] {
-    const lines: string[] = [];
+): string[][] {
+    const grid: string[][] = [];
     const candles = chart._candles;
     if (idx < 0 || idx >= candles.count) {
-        return lines;
+        return grid;
     }
 
     const catIdx = candles.catIdx[idx];
@@ -212,6 +208,34 @@ export function buildCandlestickTooltipLines(
     const high = candles.high[idx];
     const low = candles.low[idx];
 
+    const categoryText = candleCategoryText(chart, catIdx);
+    if (categoryText !== "") {
+        grid.push([categoryText]);
+    }
+
+    if (splitIdx >= 0 && chart._splitPrefixes.length > 1) {
+        const prefix = chart._splitPrefixes[splitIdx];
+        if (prefix) {
+            grid.push([prefix]);
+        }
+    }
+
+    const openFmt = chart.getColumnFormatter(chart._columnSlots[0], "value");
+    const closeFmt = chart.getColumnFormatter(chart._columnSlots[1], "value");
+    const highFmt = chart.getColumnFormatter(chart._columnSlots[2], "value");
+    const lowFmt = chart.getColumnFormatter(chart._columnSlots[3], "value");
+    grid.push(["Open", openFmt(open)]);
+    grid.push(["Close", closeFmt(close)]);
+    grid.push(["High", highFmt(high)]);
+    grid.push(["Low", lowFmt(low)]);
+
+    return grid;
+}
+
+export function candleCategoryText(
+    chart: CandlestickChart,
+    catIdx: number,
+): string {
     if (
         chart._categoryAxisMode === "numeric" &&
         chart._numericCategoryDomain &&
@@ -219,8 +243,10 @@ export function buildCandlestickTooltipLines(
     ) {
         const v = chart._categoryPositions[catIdx];
         const xColumn = chart._groupBy[0];
-        lines.push(chart.getColumnFormatter(xColumn, "value")(v));
-    } else if (chart._rowPaths.length > 0) {
+        return chart.getColumnFormatter(xColumn, "value")(v);
+    }
+
+    if (chart._rowPaths.length > 0) {
         const parts: string[] = [];
         for (const rp of chart._rowPaths) {
             const s = rp.labels[catIdx] ?? "";
@@ -229,28 +255,8 @@ export function buildCandlestickTooltipLines(
             }
         }
 
-        if (parts.length > 0) {
-            lines.push(parts.join(" › "));
-        }
-    } else {
-        lines.push(`Row ${catIdx + chart._rowOffset}`);
+        return parts.join(" › ");
     }
 
-    if (splitIdx >= 0 && chart._splitPrefixes.length > 1) {
-        const prefix = chart._splitPrefixes[splitIdx];
-        if (prefix) {
-            lines.push(prefix);
-        }
-    }
-
-    const openFmt = chart.getColumnFormatter(chart._columnSlots[0], "value");
-    const closeFmt = chart.getColumnFormatter(chart._columnSlots[1], "value");
-    const highFmt = chart.getColumnFormatter(chart._columnSlots[2], "value");
-    const lowFmt = chart.getColumnFormatter(chart._columnSlots[3], "value");
-    lines.push(`Open: ${openFmt(open)}`);
-    lines.push(`Close: ${closeFmt(close)}`);
-    lines.push(`High: ${highFmt(high)}`);
-    lines.push(`Low: ${lowFmt(low)}`);
-
-    return lines;
+    return `Row ${catIdx + chart._rowOffset}`;
 }

--- a/packages/viewer-charts/src/ts/charts/candlestick/candlestick-render.ts
+++ b/packages/viewer-charts/src/ts/charts/candlestick/candlestick-render.ts
@@ -16,7 +16,12 @@ import { PlotLayout } from "../../layout/plot-layout";
 import { sampleGradient } from "../../theme/gradient";
 import { renderInPlotFrame } from "../../webgl/plot-frame";
 import { renderCanvasTooltip } from "../../interaction/tooltip-controller";
-import { computeNiceTicks } from "../../layout/ticks";
+import { tooltipStyleOf } from "../../interaction/tooltip-grid";
+import {
+    renderAxisHoverIndicators,
+    type AxisIndicator,
+} from "../../interaction/axis-indicators";
+import { computeNiceTicks, stepTickFormatter } from "../../layout/ticks";
 import { type AxisDomain } from "../../axis/numeric-axis";
 import {
     renderBarAxesChrome,
@@ -27,7 +32,10 @@ import {
     measureCategoricalAxisHeight,
     type CategoricalDomain,
 } from "../../axis/categorical-axis";
-import { buildCandlestickTooltipLines } from "./candlestick-interact";
+import {
+    buildCandlestickTooltipLines,
+    candleCategoryText,
+} from "./candlestick-interact";
 import {
     computeVisibleExtent,
     type VisibleExtent,
@@ -321,18 +329,73 @@ function renderCandlestickTooltip(chart: CandlestickChart): void {
     const pos = layout.dataToPixel(xCenter, yMid);
     const lines = buildCandlestickTooltipLines(chart, i);
     const theme = chart._resolveTheme();
-    renderCanvasTooltip(
+    const dpr = chart._glManager?.dpr ?? 1;
+
+    let valueColumn = chart._columnSlots[1];
+    let value = candles.close[i];
+    if (valueColumn == null || !Number.isFinite(value)) {
+        valueColumn =
+            chart._columnSlots[0] ??
+            chart._columnSlots[2] ??
+            chart._columnSlots[3];
+        value = candles.open[i];
+    }
+
+    const datumPos = layout.dataToPixel(xCenter, value);
+    const indicators: AxisIndicator[] = [];
+
+    let categoryText: string;
+    if (
+        chart._categoryAxisMode === "numeric" &&
+        chart._numericCategoryDomain &&
+        chart._categoryPositions
+    ) {
+        const catFmt =
+            chart.getColumnFormatter(chart._groupBy[0], "tick") ??
+            stepTickFormatter(
+                chart._numericCategoryDomain.isDate,
+                chart._lastCatTicks,
+            );
+        categoryText = catFmt(chart._categoryPositions[candles.catIdx[i]]);
+    } else {
+        categoryText = candleCategoryText(chart, candles.catIdx[i]);
+    }
+
+    if (categoryText !== "") {
+        indicators.push({
+            side: "bottom",
+            px: datumPos.px,
+            py: datumPos.py,
+            text: categoryText,
+        });
+    }
+
+    if (Number.isFinite(value)) {
+        const valueFmt =
+            chart.getColumnFormatter(valueColumn, "tick") ??
+            stepTickFormatter(chart._lastYDomain?.isDate, chart._lastYTicks);
+        indicators.push({
+            side: "left",
+            px: datumPos.px,
+            py: datumPos.py,
+            text: valueFmt(value),
+        });
+    }
+
+    renderAxisHoverIndicators(
         chart._chromeCanvas,
-        pos,
-        lines,
         layout,
         theme,
-        chart._glManager?.dpr ?? 1,
-        {
-            crosshair: false,
-            highlightRadius: 0,
-        },
+        dpr,
+        indicators,
+        chart._pluginConfig.tooltip_opacity,
     );
+
+    renderCanvasTooltip(chart._chromeCanvas, pos, lines, layout, theme, dpr, {
+        ...tooltipStyleOf(chart._pluginConfig),
+        crosshair: false,
+        highlightRadius: 0,
+    });
 }
 
 /**

--- a/packages/viewer-charts/src/ts/charts/cartesian/cartesian-interact.ts
+++ b/packages/viewer-charts/src/ts/charts/cartesian/cartesian-interact.ts
@@ -12,6 +12,7 @@
 
 import type { CartesianChart } from "./cartesian";
 import { renderCartesianChromeOverlay } from "./cartesian-render";
+import { tooltipStyleOf } from "../../interaction/tooltip-grid";
 
 const TOOLTIP_RADIUS_PX = 24;
 
@@ -311,7 +312,7 @@ export function showCartesianPinnedTooltip(
     );
 
     const serial = chart._lazyTooltip.beginPin();
-    chart.glyph.buildTooltipLines(chart, pointIdx).then((lines) => {
+    chart.glyph.buildTooltipLines(chart, pointIdx).then((grid) => {
         // Abandon the pin if the user moved on (another pin/dismiss
         // between click and resolve) or the underlying view changed.
         if (!chart._lazyTooltip.isPinFresh(serial)) {
@@ -322,11 +323,16 @@ export function showCartesianPinnedTooltip(
             return;
         }
 
-        if (lines.length === 0) {
+        if (grid.length === 0) {
             return;
         }
 
-        chart._tooltip.pin(lines, pos, layout);
+        chart._tooltip.pin(
+            grid,
+            pos,
+            layout,
+            tooltipStyleOf(chart._pluginConfig),
+        );
     });
 
     chart._hoveredIndex = -1;

--- a/packages/viewer-charts/src/ts/charts/cartesian/cartesian-render.ts
+++ b/packages/viewer-charts/src/ts/charts/cartesian/cartesian-render.ts
@@ -31,6 +31,11 @@ import {
 } from "../../webgl/plot-frame";
 import { ensureGradientTexture } from "../../webgl/gradient-texture";
 import { renderCanvasTooltip } from "../../interaction/tooltip-controller";
+import { tooltipStyleOf } from "../../interaction/tooltip-grid";
+import {
+    renderAxisHoverIndicators,
+    type AxisIndicator,
+} from "../../interaction/axis-indicators";
 import {
     computeTicks,
     renderGridlines,
@@ -42,6 +47,8 @@ import {
 } from "../../axis/numeric-axis";
 import { initCanvas, getScaledContext } from "../../axis/canvas";
 import { computeMapDegreeTicks } from "../../axis/map-ticks";
+import { mercatorToLonLat } from "../../map/mercator";
+import { stepTickFormatter } from "../../layout/ticks";
 import {
     type CategoricalDomain,
     type CategoricalLevel,
@@ -1190,7 +1197,9 @@ function renderFacetedChromeOverlay(chart: CartesianChart): void {
         const dataY = chart._yData[chart._hoveredIndex] + yOrigin;
         const sourceFacet = seriesFromIndex(chart, chart._hoveredIndex);
         const opts = chart.glyph.tooltipOptions();
-        const tooltipLines = chart._lazyTooltip.lines ?? [];
+        const axisInd = axisIndicatorsEnabled(chart, opts);
+        const style = tooltipStyleOf(chart._pluginConfig);
+        const tooltipGrid = chart._lazyTooltip.grid ?? [];
 
         for (let i = 0; i < grid.cells.length; i++) {
             const cell = grid.cells[i];
@@ -1209,10 +1218,28 @@ function renderFacetedChromeOverlay(chart: CartesianChart): void {
                 continue;
             }
 
+            if (isSource && axisInd) {
+                renderAxisHoverIndicators(
+                    canvas,
+                    cell.layout,
+                    theme,
+                    dpr,
+                    cartesianAxisIndicators(
+                        chart,
+                        cell.layout,
+                        pos,
+                        dataX,
+                        dataY,
+                    ),
+                    style.opacity,
+                );
+            }
+
             const coordinated = chart._facetConfig.coordinated_tooltip;
-            const lines = isSource || coordinated ? tooltipLines : [];
-            renderCanvasTooltip(canvas, pos, lines, cell.layout, theme, dpr, {
-                crosshair: opts.crosshair,
+            const content = isSource || coordinated ? tooltipGrid : [];
+            renderCanvasTooltip(canvas, pos, content, cell.layout, theme, dpr, {
+                ...style,
+                crosshair: opts.crosshair && (!isSource || !axisInd),
                 highlightRadius: isSource ? opts.highlightRadius : 0,
             });
         }
@@ -1337,24 +1364,76 @@ function renderTooltip(
 
     const xOrigin = isNaN(chart._xOrigin) ? 0 : chart._xOrigin;
     const yOrigin = isNaN(chart._yOrigin) ? 0 : chart._yOrigin;
-    const pos = layout.dataToPixel(
-        chart._xData[idx] + xOrigin,
-        chart._yData[idx] + yOrigin,
-    );
+    const dataX = chart._xData[idx] + xOrigin;
+    const dataY = chart._yData[idx] + yOrigin;
+    const pos = layout.dataToPixel(dataX, dataY);
 
     // Lines come from the async lazy tooltip fetch kicked off in
     // `handleCartesianHover`. While a fetch is in flight this is
     // `null`; the canvas tooltip helper still paints the crosshair /
     // highlight ring but skips the text box.
-    const lines = chart._lazyTooltip.lines ?? [];
+    const grid = chart._lazyTooltip.grid ?? [];
     const theme = chart._resolveTheme();
-    renderCanvasTooltip(
-        canvas,
-        pos,
-        lines,
-        layout,
-        theme,
-        chart._glManager?.dpr ?? 1,
-        chart.glyph.tooltipOptions(),
+    const dpr = chart._glManager?.dpr ?? 1;
+    const opts = chart.glyph.tooltipOptions();
+    const axisInd = axisIndicatorsEnabled(chart, opts);
+    if (axisInd) {
+        renderAxisHoverIndicators(
+            canvas,
+            layout,
+            theme,
+            dpr,
+            cartesianAxisIndicators(chart, layout, pos, dataX, dataY),
+            chart._pluginConfig.tooltip_opacity,
+        );
+    }
+
+    renderCanvasTooltip(canvas, pos, grid, layout, theme, dpr, {
+        ...tooltipStyleOf(chart._pluginConfig),
+        crosshair: opts.crosshair && !axisInd,
+        highlightRadius: opts.highlightRadius,
+    });
+}
+
+function axisIndicatorsEnabled(
+    chart: CartesianChart,
+    opts: { axisIndicators: boolean },
+): boolean {
+    return (
+        opts.axisIndicators &&
+        (chart._renderMode !== "map" || !!chart._pluginConfig.numeric_axes)
     );
+}
+
+function cartesianAxisIndicators(
+    chart: CartesianChart,
+    layout: PlotLayout,
+    pos: { px: number; py: number },
+    dataX: number,
+    dataY: number,
+): AxisIndicator[] {
+    let xText: string;
+    let yText: string;
+    const xOverride = chart.getColumnFormatter(chart._xName, "tick");
+    const yOverride = chart.getColumnFormatter(chart._yName, "tick");
+    if (chart._renderMode === "map") {
+        const mt = computeMapDegreeTicks(layout);
+        const [lon, lat] = mercatorToLonLat(dataX, dataY);
+        xText = xOverride ? xOverride(lon) : mt.formatX(dataX);
+        yText = yOverride ? yOverride(lat) : mt.formatY(dataY);
+    } else {
+        const xFmt =
+            xOverride ??
+            stepTickFormatter(chart._lastXDomain?.isDate, chart._lastXTicks);
+        const yFmt =
+            yOverride ??
+            stepTickFormatter(chart._lastYDomain?.isDate, chart._lastYTicks);
+        xText = xFmt(dataX);
+        yText = yFmt(dataY);
+    }
+
+    return [
+        { side: "bottom", px: pos.px, py: pos.py, text: xText },
+        { side: "left", px: pos.px, py: pos.py, text: yText },
+    ];
 }

--- a/packages/viewer-charts/src/ts/charts/cartesian/glyph.ts
+++ b/packages/viewer-charts/src/ts/charts/cartesian/glyph.ts
@@ -67,12 +67,16 @@ export interface Glyph {
     buildTooltipLines(
         chart: CartesianChart,
         flatIdx: number,
-    ): Promise<string[]>;
+    ): Promise<string[][]>;
 
     /**
      * Hover-overlay options (crosshair, highlight radius).
      */
-    tooltipOptions(): { crosshair: boolean; highlightRadius: number };
+    tooltipOptions(): {
+        crosshair: boolean;
+        highlightRadius: number;
+        axisIndicators: boolean;
+    };
 
     /**
      * Release GL resources created by `ensureProgram`.

--- a/packages/viewer-charts/src/ts/charts/cartesian/glyphs/density.ts
+++ b/packages/viewer-charts/src/ts/charts/cartesian/glyphs/density.ts
@@ -309,12 +309,12 @@ export class DensityGlyph implements Glyph {
     buildTooltipLines(
         chart: CartesianChart,
         flatIdx: number,
-    ): Promise<string[]> {
+    ): Promise<string[][]> {
         return buildPointRowTooltipLines(chart, flatIdx);
     }
 
     tooltipOptions() {
-        return { crosshair: true, highlightRadius: 0 };
+        return { crosshair: true, highlightRadius: 0, axisIndicators: true };
     }
 
     destroy(chart: CartesianChart): void {

--- a/packages/viewer-charts/src/ts/charts/cartesian/glyphs/lines.ts
+++ b/packages/viewer-charts/src/ts/charts/cartesian/glyphs/lines.ts
@@ -125,17 +125,17 @@ export class LineGlyph implements Glyph {
     async buildTooltipLines(
         chart: CartesianChart,
         flatIdx: number,
-    ): Promise<string[]> {
-        const lines: string[] = [];
+    ): Promise<string[][]> {
+        const grid: string[][] = [];
         if (!chart._xData || !chart._yData) {
-            return lines;
+            return grid;
         }
 
         if (chart._splitGroups.length > 0 && chart._seriesCapacity > 0) {
             const seriesIdx = Math.floor(flatIdx / chart._seriesCapacity);
             const sg = chart._splitGroups[seriesIdx];
             if (sg) {
-                lines.push(sg.prefix);
+                grid.push([sg.prefix]);
             }
         }
 
@@ -147,20 +147,20 @@ export class LineGlyph implements Glyph {
         const xFormatted = xIsDate
             ? formatDateTickValue(xVal)
             : formatTickValue(xVal);
-        lines.push(`${chart._xLabel || "Row"}: ${xFormatted}`);
+        grid.push([chart._xLabel || "Row", xFormatted]);
 
         const yType = chart._columnTypes[chart._yLabel] || "";
         const yIsDate = yType === "date" || yType === "datetime";
         const yFormatted = yIsDate
             ? formatDateTickValue(yVal)
             : formatTickValue(yVal);
-        lines.push(`${chart._yLabel}: ${yFormatted}`);
+        grid.push([chart._yLabel, yFormatted]);
 
-        return lines;
+        return grid;
     }
 
     tooltipOptions() {
-        return { crosshair: true, highlightRadius: 5 };
+        return { crosshair: true, highlightRadius: 5, axisIndicators: true };
     }
 
     destroy(chart: CartesianChart): void {

--- a/packages/viewer-charts/src/ts/charts/cartesian/glyphs/points.ts
+++ b/packages/viewer-charts/src/ts/charts/cartesian/glyphs/points.ts
@@ -131,12 +131,12 @@ export class PointGlyph implements Glyph {
     buildTooltipLines(
         chart: CartesianChart,
         flatIdx: number,
-    ): Promise<string[]> {
+    ): Promise<string[][]> {
         return buildPointRowTooltipLines(chart, flatIdx);
     }
 
     tooltipOptions() {
-        return { crosshair: true, highlightRadius: 6 };
+        return { crosshair: true, highlightRadius: 6, axisIndicators: true };
     }
 
     destroy(_chart: CartesianChart): void {

--- a/packages/viewer-charts/src/ts/charts/cartesian/tooltip-lines.ts
+++ b/packages/viewer-charts/src/ts/charts/cartesian/tooltip-lines.ts
@@ -24,22 +24,22 @@ import type { CartesianChart } from "./cartesian";
 export async function buildPointRowTooltipLines(
     chart: CartesianChart,
     flatIdx: number,
-): Promise<string[]> {
-    const lines: string[] = [];
+): Promise<string[][]> {
+    const grid: string[][] = [];
     if (!chart._rowIndexData || !chart._lazyRows) {
-        return lines;
+        return grid;
     }
 
     const rowIdx = chart._rowIndexData[flatIdx];
     if (rowIdx < 0) {
-        return lines;
+        return grid;
     }
 
     if (chart._splitGroups.length > 0 && chart._seriesCapacity > 0) {
         const seriesIdx = Math.floor(flatIdx / chart._seriesCapacity);
         const sg = chart._splitGroups[seriesIdx];
         if (sg?.prefix) {
-            lines.push(sg.prefix);
+            grid.push([sg.prefix]);
         }
     }
 
@@ -70,11 +70,11 @@ export async function buildPointRowTooltipLines(
 
         if (typeof value === "number") {
             const formatted = chart.getColumnFormatter(colName, "value")(value);
-            lines.push(`${displayName}: ${formatted}`);
+            grid.push([displayName, formatted]);
         } else {
-            lines.push(`${displayName}: ${value}`);
+            grid.push([displayName, String(value)]);
         }
     }
 
-    return lines;
+    return grid;
 }

--- a/packages/viewer-charts/src/ts/charts/chart-base.ts
+++ b/packages/viewer-charts/src/ts/charts/chart-base.ts
@@ -21,7 +21,11 @@ import {
 } from "@perspective-dev/viewer/src/ts/column-format.js";
 import type { ColumnDataMap } from "../data/view-reader";
 import { LazyRowFetcher } from "../data/lazy-row";
-import { formatTickValue, formatDateTickValue } from "../layout/ticks";
+import {
+    CHART_DATE_DEFAULTS,
+    CHART_DATETIME_DEFAULTS,
+    CHART_NUMBER_DEFAULTS,
+} from "../plugin/format-defaults";
 import type { WebGLContextManager } from "../webgl/context-manager";
 import {
     ZoomController,
@@ -48,46 +52,30 @@ import { resolveThemeFromVars, type Theme } from "../theme/theme";
 import { applyColumnColorOverrides } from "../theme/overrides";
 import { requestRender as scheduleRender } from "../render/scheduler";
 
-// TODO I don't know if this is the behavior we want. On the plus side, this
-// ad-hoc formatter scales well to small and large data ranges, making a good
-// guess at the right format without user input. On the minus side, this
-// behavior is inconsistent with datagrid and the rest of the app, and the ad-hoc
-// surprising behavior when overriding one field in `number_format` and suddenly
-// the entire formatter is replaced.
-const REGRESSION_BEHAVIOR = true;
-
 /**
- * Locale-aware fallback formatter applied to numeric tooltip / legend
- * values when the column has no `number_format` configured. Two
- * fractional digits matches the legacy datagrid default and gives
- * tooltips a stable display width.
+ * Fallback formatter applied to numeric tooltip / legend values when the
+ * column has no `number_format` configured.
  */
 const DEFAULT_VALUE_FORMATTER: (v: number) => string = ((): ((
     v: number,
 ) => string) => {
-    if (REGRESSION_BEHAVIOR) {
-        return formatTickValue;
-    } else {
-        const intl = createNumberFormatter("float");
-        return (v) => intl.format(v);
-    }
+    const intl = createNumberFormatter(
+        "float",
+        undefined,
+        CHART_NUMBER_DEFAULTS,
+    );
+    return (v) => intl.format(v);
 })();
 
 /**
- * Locale-aware fallback formatter for datetime tooltip / legend values
- * when the column has no `date_format` configured. Uses the locale
- * default (no `dateStyle` / `timeStyle`) to match what most users
- * expect from an `Intl.DateTimeFormat()` constructed with no options.
+ * Fallback formatter for datetime tooltip / legend values when the
+ * column has no `date_format` configured.
  */
 const DEFAULT_DATETIME_FORMATTER: (v: number) => string = ((): ((
     v: number,
 ) => string) => {
-    if (REGRESSION_BEHAVIOR) {
-        return formatDateTickValue;
-    } else {
-        const intl = createDatetimeFormatter();
-        return (v) => intl.format(v);
-    }
+    const intl = createDatetimeFormatter(undefined, CHART_DATETIME_DEFAULTS);
+    return (v) => intl.format(v);
 })();
 
 /**
@@ -497,7 +485,11 @@ export abstract class AbstractChart implements ChartImplementation {
                 return undefined;
             }
 
-            const intl = createNumberFormatter(type, numberFormat);
+            const intl = createNumberFormatter(
+                type,
+                numberFormat,
+                CHART_NUMBER_DEFAULTS,
+            );
             return (v) => intl.format(v);
         }
 
@@ -507,7 +499,10 @@ export abstract class AbstractChart implements ChartImplementation {
                 return undefined;
             }
 
-            const intl = createDatetimeFormatter(dateFormat);
+            const intl = createDatetimeFormatter(
+                dateFormat,
+                CHART_DATETIME_DEFAULTS,
+            );
             return (v) => intl.format(v);
         }
 
@@ -517,7 +512,7 @@ export abstract class AbstractChart implements ChartImplementation {
                 return undefined;
             }
 
-            const intl = createDateFormatter(dateFormat);
+            const intl = createDateFormatter(dateFormat, CHART_DATE_DEFAULTS);
             return (v) => intl.format(v);
         }
 

--- a/packages/viewer-charts/src/ts/charts/chart.ts
+++ b/packages/viewer-charts/src/ts/charts/chart.ts
@@ -520,6 +520,22 @@ export interface PluginConfig {
     legend_x: number;
     legend_y: number;
     legend_opacity: number;
+
+    /**
+     * Per-column width cap for tooltip grid cells, in CSS pixels.
+     * Cells wider than this ellipsize; spanning (single-cell) rows cap
+     * at the full two-column budget. The default keeps a two-column
+     * name/value tooltip comfortably inside a small panel.
+     */
+    tooltip_max_column_px: number;
+
+    /**
+     * Tooltip background/border alpha (0..1). Applies to hover boxes,
+     * pinned tooltips, and the axis hover-indicator badges; text
+     * always paints at full alpha so a translucent tooltip stays
+     * readable.
+     */
+    tooltip_opacity: number;
 }
 
 export type LegendAnchor =
@@ -558,4 +574,6 @@ export const DEFAULT_PLUGIN_CONFIG: PluginConfig = {
     legend_x: 0,
     legend_y: 0,
     legend_opacity: 0.8,
+    tooltip_max_column_px: 160,
+    tooltip_opacity: 0.8,
 };

--- a/packages/viewer-charts/src/ts/charts/chart.ts
+++ b/packages/viewer-charts/src/ts/charts/chart.ts
@@ -521,20 +521,10 @@ export interface PluginConfig {
     legend_y: number;
     legend_opacity: number;
 
-    /**
-     * Per-column width cap for tooltip grid cells, in CSS pixels.
-     * Cells wider than this ellipsize; spanning (single-cell) rows cap
-     * at the full two-column budget. The default keeps a two-column
-     * name/value tooltip comfortably inside a small panel.
-     */
+    /** Per-column width cap for tooltip grid cells, in CSS pixels. */
     tooltip_max_column_px: number;
 
-    /**
-     * Tooltip background/border alpha (0..1). Applies to hover boxes,
-     * pinned tooltips, and the axis hover-indicator badges; text
-     * always paints at full alpha so a translucent tooltip stays
-     * readable.
-     */
+    /** Tooltip background/border alpha (0..1). */
     tooltip_opacity: number;
 }
 

--- a/packages/viewer-charts/src/ts/charts/common/draw-tooltip-box.ts
+++ b/packages/viewer-charts/src/ts/charts/common/draw-tooltip-box.ts
@@ -12,6 +12,13 @@
 
 import type { Context2D } from "../canvas-types";
 import type { Theme } from "../../theme/theme";
+import {
+    measureTooltipGrid,
+    paintTooltipGrid,
+    DEFAULT_TOOLTIP_STYLE,
+    type TooltipContent,
+    type TooltipStyle,
+} from "../../interaction/tooltip-grid";
 
 /**
  * Draw a freestanding tooltip box anchored near (cx, cy), measuring
@@ -22,32 +29,21 @@ import type { Theme } from "../../theme/theme";
 export function drawTooltipBox(
     ctx: Context2D,
     theme: Theme,
-    lines: string[],
+    grid: TooltipContent,
     cx: number,
     cy: number,
     cssWidth: number,
     cssHeight: number,
     fontFamily: string,
+    style: TooltipStyle = DEFAULT_TOOLTIP_STYLE,
 ): void {
-    if (lines.length === 0) {
+    if (grid.length === 0) {
         return;
     }
 
-    const { tooltipBg, tooltipText, tooltipBorder } = theme;
-
     ctx.font = `11px ${fontFamily}`;
-    const lineHeight = 16;
-    const padding = 8;
-    let maxWidth = 0;
-    for (const line of lines) {
-        const w = ctx.measureText(line).width;
-        if (w > maxWidth) {
-            maxWidth = w;
-        }
-    }
-
-    const boxW = maxWidth + padding * 2;
-    const boxH = lines.length * lineHeight + padding * 2 - 4;
+    const measured = measureTooltipGrid(ctx, grid, style.maxColumnPx);
+    const { boxW, boxH } = measured;
 
     let tx = cx + 12;
     let ty = cy - boxH - 8;
@@ -67,18 +63,5 @@ export function drawTooltipBox(
         ty = cssHeight - boxH - 4;
     }
 
-    ctx.fillStyle = tooltipBg;
-    ctx.strokeStyle = tooltipBorder;
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.roundRect(tx, ty, boxW, boxH, 4);
-    ctx.fill();
-    ctx.stroke();
-
-    ctx.fillStyle = tooltipText;
-    ctx.textAlign = "left";
-    ctx.textBaseline = "top";
-    for (let i = 0; i < lines.length; i++) {
-        ctx.fillText(lines[i], tx + padding, ty + padding + i * lineHeight);
-    }
+    paintTooltipGrid(ctx, measured, tx, ty, theme, style.opacity);
 }

--- a/packages/viewer-charts/src/ts/charts/common/tree-chrome.ts
+++ b/packages/viewer-charts/src/ts/charts/common/tree-chrome.ts
@@ -31,6 +31,7 @@ import {
 } from "../../interaction/legend-controller";
 import type { TreeChartBase } from "./tree-chart";
 import { drawTooltipBox } from "./draw-tooltip-box";
+import { tooltipStyleOf } from "../../interaction/tooltip-grid";
 
 /**
  * Click target for one breadcrumb segment. Tree-chart hit-testing
@@ -120,23 +121,24 @@ export function renderTreeTooltip(
     cssHeight: number,
     fontFamily: string,
 ): void {
-    const lines =
+    const grid =
         chart._lazyTooltip.hoveredTarget === nodeId
-            ? (chart._lazyTooltip.lines ?? [])
+            ? (chart._lazyTooltip.grid ?? [])
             : [];
-    if (lines.length === 0) {
+    if (grid.length === 0) {
         return;
     }
 
     drawTooltipBox(
         ctx,
         chart._resolveTheme(),
-        lines,
+        grid,
         cx,
         cy,
         cssWidth,
         cssHeight,
         fontFamily,
+        tooltipStyleOf(chart._pluginConfig),
     );
 }
 

--- a/packages/viewer-charts/src/ts/charts/common/tree-interact.ts
+++ b/packages/viewer-charts/src/ts/charts/common/tree-interact.ts
@@ -13,6 +13,7 @@
 import type { TreeChartBase } from "./tree-chart";
 import { NULL_NODE, ancestorNames } from "./node-store";
 import { rebuildBreadcrumbs } from "./tree-data";
+import { tooltipStyleOf } from "../../interaction/tooltip-grid";
 
 /**
  * Common subset of `TreemapChart` / `SunburstChart` reached by the
@@ -73,9 +74,9 @@ export async function emitTreeNodeEvent(
 export async function buildTreeTooltipLines(
     chart: TreeInteractChart,
     nodeId: number,
-): Promise<string[]> {
+): Promise<string[][]> {
     const store = chart._nodeStore;
-    const lines: string[] = [];
+    const grid: string[][] = [];
 
     const pathNames: string[] = [];
     let p = nodeId;
@@ -86,19 +87,17 @@ export async function buildTreeTooltipLines(
 
     pathNames.reverse();
     if (pathNames.length > 0) {
-        lines.push(pathNames.join(" › "));
+        grid.push([pathNames.join(" › ")]);
     } else {
-        lines.push(store.name[nodeId]);
+        grid.push([store.name[nodeId]]);
     }
 
     const sizeFmt = chart.getColumnFormatter(chart._sizeName, "value");
-    lines.push(`Value: ${sizeFmt(store.value[nodeId])}`);
+    grid.push(["Value", sizeFmt(store.value[nodeId])]);
 
     if (chart._colorName && !isNaN(store.colorValue[nodeId])) {
         const colorFmt = chart.getColumnFormatter(chart._colorName, "value");
-        lines.push(
-            `${chart._colorName}: ${colorFmt(store.colorValue[nodeId])}`,
-        );
+        grid.push([chart._colorName, colorFmt(store.colorValue[nodeId])]);
     }
 
     const rowIdx = store.leafRowIdx[nodeId];
@@ -117,20 +116,21 @@ export async function buildTreeTooltipLines(
             }
 
             if (typeof value === "number") {
-                lines.push(
-                    `${name}: ${chart.getColumnFormatter(name, "value")(value)}`,
-                );
+                grid.push([
+                    name,
+                    chart.getColumnFormatter(name, "value")(value),
+                ]);
             } else {
-                lines.push(`${name}: ${value}`);
+                grid.push([name, String(value)]);
             }
         }
     }
 
     if (store.firstChild[nodeId] !== NULL_NODE) {
-        lines.push(`Children: ${store.childCount[nodeId]}`);
+        grid.push(["Children", String(store.childCount[nodeId])]);
     }
 
-    return lines;
+    return grid;
 }
 
 /**
@@ -150,19 +150,20 @@ export function showTreePinnedTooltip(
     const cssWidth = chart._glManager?.cssWidth ?? 0;
     const cssHeight = chart._glManager?.cssHeight ?? 0;
 
-    buildTreeTooltipLines(chart, nodeId).then((lines) => {
+    buildTreeTooltipLines(chart, nodeId).then((grid) => {
         if (chart._pinnedNodeId !== nodeId) {
             return;
         }
 
-        if (lines.length === 0) {
+        if (grid.length === 0) {
             return;
         }
 
         chart._tooltip.pin(
-            lines,
+            grid,
             { px: anchor.cx, py: anchor.cy },
             { cssWidth, cssHeight },
+            tooltipStyleOf(chart._pluginConfig),
         );
     });
 

--- a/packages/viewer-charts/src/ts/charts/heatmap/heatmap-interact.ts
+++ b/packages/viewer-charts/src/ts/charts/heatmap/heatmap-interact.ts
@@ -13,6 +13,12 @@
 import type { HeatmapChart } from "./heatmap";
 import type { HeatmapCell } from "./heatmap-build";
 import { renderCanvasTooltip } from "../../interaction/tooltip-controller";
+import {
+    renderAxisHoverIndicators,
+    type AxisIndicator,
+} from "../../interaction/axis-indicators";
+import { computeNiceTicks, stepTickFormatter } from "../../layout/ticks";
+import { tooltipStyleOf } from "../../interaction/tooltip-grid";
 import type { CategoricalLevel } from "../../axis/categorical-axis";
 
 /**
@@ -216,6 +222,8 @@ export function renderHeatmapTooltip(chart: HeatmapChart): void {
     let xLevels: CategoricalLevel[];
     let yLevels: CategoricalLevel[];
     let xPositions: Float64Array | null;
+    let yPositions: Float64Array | null;
+    let xNumericDomain: { isDate?: boolean } | null;
     let facetLabel: string | null = null;
 
     if (chart._hoveredFacetIdx >= 0) {
@@ -228,6 +236,8 @@ export function renderHeatmapTooltip(chart: HeatmapChart): void {
         xLevels = facet.pipeline.xLevels;
         yLevels = facet.pipeline.yLevels;
         xPositions = facet.pipeline.xPositions;
+        yPositions = facet.pipeline.yPositions;
+        xNumericDomain = facet.pipeline.xNumericDomain;
         facetLabel = facet.label;
     } else {
         if (!chart._lastLayout) {
@@ -238,6 +248,8 @@ export function renderHeatmapTooltip(chart: HeatmapChart): void {
         xLevels = chart._xLevels;
         yLevels = chart._yLevels;
         xPositions = chart._xPositions;
+        yPositions = chart._yPositions;
+        xNumericDomain = chart._xNumericDomain;
     }
 
     const cell = chart._hoveredCell;
@@ -247,9 +259,9 @@ export function renderHeatmapTooltip(chart: HeatmapChart): void {
     // many pixels.
     const pos = { px: chart._hoveredMouseX, py: chart._hoveredMouseY };
 
-    const lines: string[] = [];
+    const grid: string[][] = [];
     if (facetLabel) {
-        lines.push(facetLabel);
+        grid.push([facetLabel]);
     }
 
     const xPath =
@@ -261,23 +273,69 @@ export function renderHeatmapTooltip(chart: HeatmapChart): void {
             : formatHierarchicalPath(xLevels, cell.xIdx);
     const yPath = formatHierarchicalPath(yLevels, cell.yIdx);
     if (xPath) {
-        lines.push(xPath);
+        grid.push([xPath]);
     }
 
     if (yPath) {
-        lines.push(yPath);
+        grid.push([yPath]);
     }
 
     const valueFmt = chart.getColumnFormatter(chart._columnSlots[0], "value");
-    lines.push(`Value: ${valueFmt(cell.value)}`);
+    grid.push(["Value", valueFmt(cell.value)]);
 
     const theme = chart._resolveTheme();
+    const dpr = chart._glManager?.dpr ?? 1;
+
+    const cellPos = layout.dataToPixel(
+        xPositions ? xPositions[cell.xIdx] : cell.xIdx,
+        yPositions ? yPositions[cell.yIdx] : cell.yIdx,
+    );
+    const badgeX =
+        chart._xAxisMode.mode === "numeric" && xPositions
+            ? (
+                  chart.getColumnFormatter(chart._groupBy[0], "tick") ??
+                  stepTickFormatter(
+                      xNumericDomain?.isDate,
+                      computeNiceTicks(layout.paddedXMin, layout.paddedXMax, 6),
+                  )
+              )(xPositions[cell.xIdx])
+            : xPath;
+
+    const indicators: AxisIndicator[] = [];
+    if (badgeX) {
+        indicators.push({
+            side: "bottom",
+            px: cellPos.px,
+            py: cellPos.py,
+            text: badgeX,
+        });
+    }
+
+    if (yPath) {
+        indicators.push({
+            side: "left",
+            px: cellPos.px,
+            py: cellPos.py,
+            text: yPath,
+        });
+    }
+
+    renderAxisHoverIndicators(
+        chart._chromeCanvas,
+        layout,
+        theme,
+        dpr,
+        indicators,
+        chart._pluginConfig.tooltip_opacity,
+    );
+
     renderCanvasTooltip(
         chart._chromeCanvas,
         pos,
-        lines,
+        grid,
         layout,
         theme,
-        chart._glManager?.dpr ?? 1,
+        dpr,
+        tooltipStyleOf(chart._pluginConfig),
     );
 }

--- a/packages/viewer-charts/src/ts/charts/series/series-interact.ts
+++ b/packages/viewer-charts/src/ts/charts/series/series-interact.ts
@@ -23,6 +23,7 @@ import {
     rightAxisDataToPixel,
     layoutForRecord,
 } from "./series-render";
+import { tooltipStyleOf } from "../../interaction/tooltip-grid";
 
 const POINT_HIT_RADIUS_PX = 10;
 
@@ -598,26 +599,26 @@ export function handleBarLegendClick(
 export function buildBarTooltipLines(
     chart: SeriesChart,
     b: SeriesChartRecord,
-): string[] {
-    const lines: string[] = [];
+): string[][] {
+    const grid: string[][] = [];
     const s = chart._series[b.seriesId];
     const categoryPath = formatBarCategoryPath(chart, b.catIdx);
     if (categoryPath) {
-        lines.push(categoryPath);
+        grid.push([categoryPath]);
     }
 
     const yFmt = chart.getColumnFormatter(s.aggName, "value");
-    lines.push(`${s.aggName}: ${yFmt(b.value)}`);
+    grid.push([s.aggName, yFmt(b.value)]);
     if (s.splitKey) {
-        lines.push(`Split: ${s.splitKey}`);
+        grid.push(["Split", s.splitKey]);
     }
 
     if (b.y0 !== 0) {
-        lines.push(`Base: ${yFmt(b.y0)}`);
-        lines.push(`Top: ${yFmt(b.y1)}`);
+        grid.push(["Base", yFmt(b.y0)]);
+        grid.push(["Top", yFmt(b.y1)]);
     }
 
-    return lines;
+    return grid;
 }
 
 /**
@@ -705,12 +706,12 @@ function pinTooltip(chart: SeriesChart, b: SeriesChartRecord): void {
                 : layout.dataToPixel(b.xCenter, anchorV)
             : rightAxisDataToPixel(chart, b.xCenter, anchorV, layout);
 
-    const lines = buildBarTooltipLines(chart, b);
-    if (lines.length === 0) {
+    const grid = buildBarTooltipLines(chart, b);
+    if (grid.length === 0) {
         return;
     }
 
-    chart._tooltip.pin(lines, pos, layout);
+    chart._tooltip.pin(grid, pos, layout, tooltipStyleOf(chart._pluginConfig));
 
     chart._hoveredBarIdx = -1;
     chart._hoveredSample = null;

--- a/packages/viewer-charts/src/ts/charts/series/series-render.ts
+++ b/packages/viewer-charts/src/ts/charts/series/series-render.ts
@@ -26,9 +26,14 @@ import {
     withScissor,
 } from "../../webgl/plot-frame";
 import { renderCanvasTooltip } from "../../interaction/tooltip-controller";
+import { tooltipStyleOf } from "../../interaction/tooltip-grid";
+import {
+    renderAxisHoverIndicators,
+    type AxisIndicator,
+} from "../../interaction/axis-indicators";
 import { drawBars, BAR_TYPE_BAR_VAL as BAR_TYPE_BAR } from "./glyphs/draw-bars";
-import { getHoveredBar } from "./series-interact";
-import { computeNiceTicks } from "../../layout/ticks";
+import { getHoveredBar, formatBarCategoryPath } from "./series-interact";
+import { computeNiceTicks, stepTickFormatter } from "../../layout/ticks";
 import {
     renderOuterXAxis,
     renderOuterYAxis,
@@ -1690,13 +1695,71 @@ function renderBarTooltipCanvas(chart: SeriesChart): void {
 
     const lines = buildBarTooltipLines(chart, b);
     const theme = chart._resolveTheme();
+    const dpr = chart._glManager?.dpr ?? 1;
+
+    const datumPos =
+        b.axis === 0
+            ? chart._isHorizontal
+                ? layout.dataToPixel(b.y1, b.xCenter)
+                : layout.dataToPixel(b.xCenter, b.y1)
+            : rightAxisDataToPixel(chart, b.xCenter, b.y1, layout);
+    const indicators: AxisIndicator[] = [];
+
+    let categoryText: string;
+    if (
+        chart._categoryAxisMode === "numeric" &&
+        chart._categoryPositions &&
+        chart._categoryPositions[b.catIdx] != null
+    ) {
+        const catFmt =
+            chart.getColumnFormatter(chart._groupBy[0], "tick") ??
+            stepTickFormatter(
+                chart._numericCategoryDomain?.isDate,
+                chart._lastCatTicks,
+            );
+        categoryText = catFmt(chart._categoryPositions[b.catIdx]);
+    } else {
+        categoryText = formatBarCategoryPath(chart, b.catIdx);
+    }
+
+    if (categoryText !== "") {
+        indicators.push({
+            side: chart._isHorizontal ? "left" : "bottom",
+            px: datumPos.px,
+            py: datumPos.py,
+            text: categoryText,
+        });
+    }
+
+    const valueDomain =
+        b.axis === 1 ? chart._lastAltYDomain : chart._lastYDomain;
+    const valueTicks = b.axis === 1 ? chart._lastAltYTicks : chart._lastYTicks;
+    const valueFmt =
+        chart.getColumnFormatter(chart._series[b.seriesId]?.aggName, "tick") ??
+        stepTickFormatter(valueDomain?.isDate, valueTicks);
+    indicators.push({
+        side: chart._isHorizontal ? "bottom" : b.axis === 1 ? "right" : "left",
+        px: datumPos.px,
+        py: datumPos.py,
+        text: valueFmt(b.y1),
+    });
+    renderAxisHoverIndicators(
+        chart._chromeCanvas,
+        layout,
+        theme,
+        dpr,
+        indicators,
+        chart._pluginConfig.tooltip_opacity,
+    );
+
     renderCanvasTooltip(
         chart._chromeCanvas,
         pos,
         lines,
         layout,
         theme,
-        chart._glManager?.dpr ?? 1,
+        dpr,
+        tooltipStyleOf(chart._pluginConfig),
     );
 }
 

--- a/packages/viewer-charts/src/ts/interaction/axis-indicators.ts
+++ b/packages/viewer-charts/src/ts/interaction/axis-indicators.ts
@@ -1,0 +1,137 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import type { Canvas2D, Context2D } from "../charts/canvas-types";
+import type { PlotLayout } from "../layout/plot-layout";
+import type { Theme } from "../theme/theme";
+
+export type AxisSide = "bottom" | "left" | "right";
+
+export interface AxisIndicator {
+    side: AxisSide;
+
+    px: number;
+    py: number;
+
+    text: string;
+}
+
+const BADGE_FONT_PX = 11;
+const BADGE_PAD_H = 4;
+const BADGE_PAD_V = 2;
+const BADGE_GAP = 4;
+
+export function renderAxisHoverIndicators(
+    canvas: Canvas2D | null,
+    layout: PlotLayout,
+    theme: Theme,
+    dpr: number,
+    indicators: AxisIndicator[],
+    opacity: number = 1.0,
+): void {
+    if (!canvas || indicators.length === 0) {
+        return;
+    }
+
+    const ctx = canvas.getContext("2d") as Context2D | null;
+    if (!ctx) {
+        return;
+    }
+
+    const plot = layout.plotRect;
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.scale(dpr, dpr);
+    ctx.font = `${BADGE_FONT_PX}px ${theme.fontFamily}`;
+
+    for (const ind of indicators) {
+        if (
+            ind.px < plot.x ||
+            ind.px > plot.x + plot.width ||
+            ind.py < plot.y ||
+            ind.py > plot.y + plot.height
+        ) {
+            continue;
+        }
+
+        drawTraceLine(ctx, ind, plot, theme);
+        drawBadge(ctx, ind, layout, theme, opacity);
+    }
+
+    ctx.restore();
+}
+
+function drawTraceLine(
+    ctx: Context2D,
+    ind: AxisIndicator,
+    plot: { x: number; y: number; width: number; height: number },
+    theme: Theme,
+): void {
+    ctx.strokeStyle = theme.tickColor;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath();
+    ctx.moveTo(ind.px, ind.py);
+    if (ind.side === "bottom") {
+        ctx.lineTo(ind.px, plot.y + plot.height);
+    } else if (ind.side === "left") {
+        ctx.lineTo(plot.x, ind.py);
+    } else {
+        ctx.lineTo(plot.x + plot.width, ind.py);
+    }
+
+    ctx.stroke();
+    ctx.setLineDash([]);
+}
+
+function drawBadge(
+    ctx: Context2D,
+    ind: AxisIndicator,
+    layout: PlotLayout,
+    theme: Theme,
+    opacity: number,
+): void {
+    const plot = layout.plotRect;
+    const boxW = ctx.measureText(ind.text).width + BADGE_PAD_H * 2;
+    const boxH = BADGE_FONT_PX + BADGE_PAD_V * 2 + 2;
+
+    let bx: number;
+    let by: number;
+    if (ind.side === "bottom") {
+        bx = ind.px - boxW / 2;
+        by = plot.y + plot.height + BADGE_GAP;
+    } else if (ind.side === "left") {
+        bx = plot.x - BADGE_GAP - boxW;
+        by = ind.py - boxH / 2;
+    } else {
+        bx = plot.x + plot.width + BADGE_GAP;
+        by = ind.py - boxH / 2;
+    }
+
+    bx = Math.min(Math.max(bx, 0), Math.max(0, layout.cssWidth - boxW));
+    by = Math.min(Math.max(by, 0), Math.max(0, layout.cssHeight - boxH));
+
+    ctx.globalAlpha = Math.min(1, Math.max(0, opacity));
+    ctx.fillStyle = theme.tooltipBg;
+    ctx.strokeStyle = theme.tooltipBorder;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.rect(bx, by, boxW, boxH);
+    ctx.fill();
+    ctx.stroke();
+    ctx.globalAlpha = 1.0;
+
+    ctx.fillStyle = theme.tooltipText;
+    ctx.textAlign = "left";
+    ctx.textBaseline = "middle";
+    ctx.fillText(ind.text, bx + BADGE_PAD_H, by + boxH / 2 + 1);
+}

--- a/packages/viewer-charts/src/ts/interaction/host-sink-dom.ts
+++ b/packages/viewer-charts/src/ts/interaction/host-sink-dom.ts
@@ -11,6 +11,13 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import type { CssBounds, HostSink } from "./tooltip-controller";
+import {
+    DEFAULT_TOOLTIP_STYLE,
+    NUMERIC_RE,
+    TOOLTIP_COL_GAP,
+    type TooltipContent,
+    type TooltipStyle,
+} from "./tooltip-grid";
 
 /**
  * Host-side `HostSink` that materializes pinned tooltips as a `<div>`
@@ -29,16 +36,17 @@ export class DomHostSink implements HostSink {
     }
 
     pin(
-        lines: string[],
+        grid: TooltipContent,
         pos: { px: number; py: number },
         bounds: CssBounds,
+        style: TooltipStyle = DEFAULT_TOOLTIP_STYLE,
     ): void {
         this.dismiss();
         const div = document.createElement("div");
 
         div.className = "webgl-tooltip";
         div.style.maxHeight = `${Math.round(bounds.cssHeight * 0.6)}px`;
-        div.textContent = lines.join("\n");
+        renderTooltipGridDom(div, grid, style);
 
         if (getComputedStyle(this._parent).position === "static") {
             this._parent.style.position = "relative";
@@ -81,5 +89,61 @@ export class DomHostSink implements HostSink {
 
     setCursor(cursor: string): void {
         this._glCanvas.style.cursor = cursor;
+    }
+}
+
+function renderTooltipGridDom(
+    root: HTMLDivElement,
+    grid: TooltipContent,
+    style: TooltipStyle,
+): void {
+    const ncols = grid.reduce((n, row) => Math.max(n, row.length), 0);
+    root.style.display = "grid";
+    root.style.gridTemplateColumns = `repeat(${Math.max(1, ncols)}, minmax(0, max-content))`;
+    root.style.columnGap = `${TOOLTIP_COL_GAP}px`;
+    if (style.opacity < 1) {
+        const pct = Math.max(0, Math.round(style.opacity * 100));
+        root.style.background = `color-mix(in srgb, var(--psp-charts--tooltip--background) ${pct}%, transparent)`;
+    }
+
+    const rightAlign: boolean[] = [];
+    for (const row of grid) {
+        if (row.length <= 1) {
+            continue;
+        }
+
+        for (let j = 1; j < row.length; j++) {
+            if (row[j] === "") {
+                continue;
+            }
+
+            const numeric = NUMERIC_RE.test(row[j]);
+            rightAlign[j] =
+                rightAlign[j] === undefined
+                    ? numeric
+                    : rightAlign[j] && numeric;
+        }
+    }
+
+    for (const row of grid) {
+        const span = row.length <= 1;
+        for (let j = 0; j < Math.max(1, row.length); j++) {
+            const cell = document.createElement("div");
+            cell.textContent = row[j] ?? "";
+            cell.style.maxWidth = `${style.maxColumnPx * (span ? 2 : 1)}px`;
+            cell.style.overflow = "hidden";
+            cell.style.textOverflow = "ellipsis";
+            cell.style.whiteSpace = "nowrap";
+            if (span) {
+                cell.style.gridColumn = "1 / -1";
+            } else if (rightAlign[j]) {
+                cell.style.textAlign = "right";
+            }
+
+            root.appendChild(cell);
+            if (span) {
+                break;
+            }
+        }
     }
 }

--- a/packages/viewer-charts/src/ts/interaction/host-sink-message.ts
+++ b/packages/viewer-charts/src/ts/interaction/host-sink-message.ts
@@ -23,6 +23,11 @@ import type {
     UserClickPayload,
     UserSelectPayload,
 } from "./tooltip-controller";
+import {
+    DEFAULT_TOOLTIP_STYLE,
+    type TooltipContent,
+    type TooltipStyle,
+} from "./tooltip-grid";
 
 /**
  * The subset of `WorkerMsg`s that flow chart → host through a
@@ -52,11 +57,12 @@ export class MessageHostSink implements HostSink {
     }
 
     pin(
-        lines: string[],
+        grid: TooltipContent,
         pos: { px: number; py: number },
         bounds: CssBounds,
+        style: TooltipStyle = DEFAULT_TOOLTIP_STYLE,
     ): void {
-        this._send({ kind: "pinTooltip", lines, pos, bounds });
+        this._send({ kind: "pinTooltip", grid, style, pos, bounds });
     }
 
     dismiss(): void {

--- a/packages/viewer-charts/src/ts/interaction/lazy-tooltip.ts
+++ b/packages/viewer-charts/src/ts/interaction/lazy-tooltip.ts
@@ -32,7 +32,7 @@ export class LazyTooltip<Target> {
     /**
      * Cached lines for the latest committed hover, or `null`.
      */
-    lines: string[] | null = null;
+    grid: string[][] | null = null;
 
     /**
      * Identity of the entity `lines` describe. `null` when cleared.
@@ -50,7 +50,7 @@ export class LazyTooltip<Target> {
      * the write.
      */
     beginHover(target: Target): number {
-        this.lines = null;
+        this.grid = null;
         this.hoveredTarget = target;
         return ++this._hoverSerial;
     }
@@ -60,12 +60,12 @@ export class LazyTooltip<Target> {
      * when the write happened (caller should repaint), false when the
      * serial was stale.
      */
-    commitHover(serial: number, lines: string[]): boolean {
+    commitHover(serial: number, grid: string[][]): boolean {
         if (serial !== this._hoverSerial) {
             return false;
         }
 
-        this.lines = lines;
+        this.grid = grid;
         return true;
     }
 
@@ -73,7 +73,7 @@ export class LazyTooltip<Target> {
      * Clear hover state (mouse left, view changed, etc.).
      */
     clearHover(): void {
-        this.lines = null;
+        this.grid = null;
         this.hoveredTarget = null;
         this._hoverSerial++;
     }

--- a/packages/viewer-charts/src/ts/interaction/tooltip-controller.ts
+++ b/packages/viewer-charts/src/ts/interaction/tooltip-controller.ts
@@ -13,10 +13,14 @@
 import type { Canvas2D, Context2D } from "../charts/canvas-types";
 import type { PlotLayout } from "../layout/plot-layout";
 import type { Theme } from "../theme/theme";
+import {
+    measureTooltipGrid,
+    paintTooltipGrid,
+    DEFAULT_TOOLTIP_STYLE,
+    type TooltipContent,
+    type TooltipStyle,
+} from "./tooltip-grid";
 
-/**
- * Minimal positioning input — PlotLayout satisfies this.
- */
 export interface CssBounds {
     cssWidth: number;
     cssHeight: number;
@@ -25,7 +29,7 @@ export interface CssBounds {
 export interface TooltipCallbacks {
     /**
      * RAF-throttled mouse position in CSS pixels, relative to the GL
-     * canvas (host already subtracted `getBoundingClientRect`).
+     * canvas.
      */
     onHover(mx: number, my: number): void;
 
@@ -35,8 +39,7 @@ export interface TooltipCallbacks {
     onLeave(): void;
 
     /**
-     * Fires on click with mouse position. Return true to consume the click
-     * (skipping the default pin/dismiss flow — used for legend clicks).
+     * Fires on click with mouse position.
      */
     onClickPre?(mx: number, my: number): boolean;
 
@@ -46,93 +49,45 @@ export interface TooltipCallbacks {
     onPin?(mx: number, my: number): void;
 
     /**
-     * Fires on dblclick (treemap drill-up gesture). Optional — charts
-     * that don't bind a handler simply ignore the event.
+     * Fires on dblclick (treemap drill-up gesture).
      */
     onDblClick?(mx: number, my: number): void;
 
     /**
-     * Fires when an active pin is dismissed by a click on the
-     * already-pinned target (the "click again to unpin" gesture in
-     * `dispatchClick`). Chart impls hook this to emit a
-     * `perspective-global-filter` with `selected: false`. Does *not*
-     * fire on the implicit dismiss inside `pin()` that replaces an
-     * existing pin — that path is followed by a fresh `onPin` which
-     * emits its own `selected: true`.
+     * Fires when an active pin is dismissed by a click.
      */
     onUnpin?(): void;
 }
 
 export interface RenderTooltipOptions {
-    /**
-     * Draw a dashed crosshair at `pos`. Used by scatter/line.
-     */
     crosshair?: boolean;
-
-    /**
-     * Draw a ring of `radius` CSS pixels at `pos`. Used to highlight a
-     * hovered point. Omit for bars (where the bar itself highlights).
-     */
     highlightRadius?: number;
+    maxColumnPx?: number;
+    opacity?: number;
 }
 
 /**
- * Side-channel from the chart back to the host's DOM. The chart calls
- * into a sink rather than touching the DOM itself; the host
- * materializes the actual visual (`<div>` for pinned tooltip, cursor
- * mutation on the GL canvas).
- *
- *   - `MessageHostSink` (in worker/) — forwards calls over a
- *                              `postMessage`-shaped channel back to
- *                              the host.
- *   - `DomHostSink` (in host transport) — receives the matching
- *                              envelopes and applies them to the DOM.
- *
- * The controller's `_pinned` flag is the source of truth for whether
- * hover updates are gated; the sink only owns the visual artifact.
+ * Side-channel from the chart back to the host's DOM.
  */
 export interface HostSink {
     pin(
-        lines: string[],
+        grid: TooltipContent,
         pos: { px: number; py: number },
         bounds: CssBounds,
+        style?: TooltipStyle,
     ): void;
     dismiss(): void;
     setCursor(cursor: string): void;
-
-    /**
-     * Forward a `perspective-click` to the host. Optional — only the
-     * worker-bound `MessageHostSink` implements it; `DomHostSink` (the
-     * host-side consumer of pin/dismiss) never sees user-event calls,
-     * so omits the implementation.
-     */
     emitUserClick?(detail: UserClickPayload): void;
-
-    /**
-     * Forward a `perspective-global-filter` to the host with the
-     * `selected: true` / `selected: false` semantics. The host owns the
-     * `removeConfigs` history (mirrors datagrid's
-     * `model._last_insert_configs`); the sink only ships the new state.
-     */
     emitUserSelect?(payload: UserSelectPayload): void;
 }
 
-/**
- * Plain-object payload for `HostSink.emitUserClick`. Matches
- * `PerspectiveClickDetail` byte-for-byte; defined locally to avoid a
- * cycle through `event-detail.ts`.
- */
 export interface UserClickPayload {
     row: Record<string, unknown>;
     column_names: string[];
     config: { filter?: unknown[] };
 }
 
-/**
- * Plain-object payload for `HostSink.emitUserSelect`. The host
- * transport reconstructs a `PerspectiveSelectDetail` class instance
- * from this plus its cached `_lastInsertConfig`.
- */
 export interface UserSelectPayload {
     selected: boolean;
     row: Record<string, unknown>;
@@ -142,13 +97,7 @@ export interface UserSelectPayload {
 
 /**
  * Owns the hover/click/dblclick state machine and the pinned-tooltip
- * lifecycle. The renderer drives this purely through
- * `dispatchHover` / `dispatchLeave` / `dispatchClick` /
- * `dispatchDblClick` — the host's `RawEventForwarder` captures DOM
- * events on the GL canvas and posts them as `InteractionEvent`s.
- *
- * Pinning + cursor changes go through a {@link HostSink} so the actual
- * DOM mutations happen host-side regardless of where the chart runs.
+ * lifecycle.
  */
 export class TooltipController {
     private _callbacks: TooltipCallbacks | null = null;
@@ -162,10 +111,7 @@ export class TooltipController {
     }
 
     /**
-     * Replace the active host sink. Dismisses any existing pin via the
-     * prior sink so we never leak a pinned artifact across resets —
-     * though in practice each chart instance uses one sink for its
-     * lifetime.
+     * Replace the active host sink.
      */
     setHost(sink: HostSink): void {
         if (this._pinned) {
@@ -177,18 +123,14 @@ export class TooltipController {
     }
 
     /**
-     * Forward a cursor change to the host. No-op when no host sink is
-     * installed (chart constructed without a transport).
+     * Forward a cursor change to the host.
      */
     setCursor(cursor: string): void {
         this._host?.setCursor(cursor);
     }
 
     /**
-     * Install the chart's tooltip callbacks. The renderer drives the
-     * controller via `dispatchHover` / `dispatchLeave` /
-     * `dispatchClick` / `dispatchDblClick`; this controller never
-     * touches the DOM directly.
+     * Install the chart's tooltip callbacks.
      */
     attach(callbacks: TooltipCallbacks): void {
         this.detach();
@@ -211,13 +153,7 @@ export class TooltipController {
 
     /**
      * Schedule an `onHover` callback for the given canvas-relative
-     * coords. Coalesces multiple calls within one animation frame so
-     * pointer streams don't backlog the chart's hit-test path.
-     *
-     * Workers ship with `requestAnimationFrame` (DedicatedWorkerGlobalScope
-     * exposes it for OffscreenCanvas painting), so the same coalescer
-     * works in both modes. We fall back to setTimeout if RAF is missing
-     * (e.g. node tests without a polyfill).
+     * coords.
      */
     dispatchHover(mx: number, my: number): void {
         if (this._pinned || !this._callbacks) {
@@ -273,20 +209,19 @@ export class TooltipController {
     }
 
     /**
-     * Pin a tooltip (or replace an active one). Forwards through the
-     * configured sink and flips the controller's pinned flag so hover
-     * dispatch is suppressed until dismissal.
+     * Pin a tooltip (or replace an active one).
      */
     pin(
-        lines: string[],
+        grid: TooltipContent,
         pos: { px: number; py: number },
         bounds: CssBounds,
+        style: TooltipStyle = DEFAULT_TOOLTIP_STYLE,
     ): void {
-        if (lines.length === 0) {
+        if (grid.length === 0) {
             return;
         }
 
-        this._host?.pin(lines, pos, bounds);
+        this._host?.pin(grid, pos, bounds, style);
         this._pinned = true;
     }
 
@@ -298,17 +233,12 @@ export class TooltipController {
 
 /**
  * Paint a canvas tooltip (crosshair, highlight ring, box + text) onto
- * `canvas`. The helper normalizes the 2D context to a DPR-scaled
- * identity transform on entry and restores prior state on exit, so it
- * composes cleanly with other chrome painters that may have already
- * called `initCanvas` on the same canvas — re-applying `scale(dpr,dpr)`
- * blind would double-scale in that case, misplacing the tooltip
- * proportionally to its distance from the origin.
+ * `canvas`.
  */
 export function renderCanvasTooltip(
     canvas: Canvas2D | null,
     pos: { px: number; py: number },
-    lines: string[],
+    grid: TooltipContent,
     layout: PlotLayout,
     theme: Theme,
     dpr: number,
@@ -327,18 +257,12 @@ export function renderCanvasTooltip(
     ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.scale(dpr, dpr);
     ctx.font = `11px ${theme.fontFamily}`;
-    const lineHeight = 16;
-    const padding = 8;
-    let maxWidth = 0;
-    for (const line of lines) {
-        const w = ctx.measureText(line).width;
-        if (w > maxWidth) {
-            maxWidth = w;
-        }
-    }
-
-    const boxW = maxWidth + padding * 2;
-    const boxH = lines.length * lineHeight + padding * 2 - 4;
+    const measured = measureTooltipGrid(
+        ctx,
+        grid,
+        options.maxColumnPx ?? DEFAULT_TOOLTIP_STYLE.maxColumnPx,
+    );
+    const { boxW, boxH } = measured;
     let tx = pos.px + 12;
     let ty = pos.py - boxH - 8;
     if (tx + boxW > layout.cssWidth) {
@@ -352,8 +276,6 @@ export function renderCanvasTooltip(
     if (ty + boxH > layout.cssHeight) {
         ty = layout.cssHeight - boxH - 4;
     }
-
-    const hasLines = lines.length > 0;
 
     // Crosshair
     if (options.crosshair) {
@@ -382,25 +304,15 @@ export function renderCanvasTooltip(
         ctx.globalAlpha = 1.0;
     }
 
-    // Box + text are only drawn when we have content. Callers pass an
-    // empty `lines` array while a lazy row fetch is still in flight —
-    // the crosshair / highlight ring above paint immediately so the
-    // hover remains visible, but the tooltip chrome waits for data.
-    if (hasLines) {
-        ctx.fillStyle = theme.tooltipBg;
-        ctx.strokeStyle = theme.tooltipBorder;
-        ctx.lineWidth = 1;
-        ctx.beginPath();
-        ctx.roundRect(tx, ty, boxW, boxH, 4);
-        ctx.fill();
-        ctx.stroke();
-
-        ctx.fillStyle = theme.tooltipText;
-        ctx.textAlign = "left";
-        ctx.textBaseline = "top";
-        for (let i = 0; i < lines.length; i++) {
-            ctx.fillText(lines[i], tx + padding, ty + padding + i * lineHeight);
-        }
+    if (grid.length > 0) {
+        paintTooltipGrid(
+            ctx,
+            measured,
+            tx,
+            ty,
+            theme,
+            options.opacity ?? DEFAULT_TOOLTIP_STYLE.opacity,
+        );
     }
 
     ctx.restore();

--- a/packages/viewer-charts/src/ts/interaction/tooltip-grid.ts
+++ b/packages/viewer-charts/src/ts/interaction/tooltip-grid.ts
@@ -1,0 +1,187 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import type { Context2D } from "../charts/canvas-types";
+import type { Theme } from "../theme/theme";
+
+export type TooltipRow = string[];
+
+export type TooltipContent = TooltipRow[];
+
+export interface TooltipStyle {
+    opacity: number;
+    maxColumnPx: number;
+}
+
+export const DEFAULT_TOOLTIP_STYLE: TooltipStyle = {
+    opacity: 1.0,
+    maxColumnPx: 160,
+};
+
+export function tooltipStyleOf(cfg: {
+    tooltip_opacity: number;
+    tooltip_max_column_px: number;
+}): TooltipStyle {
+    return {
+        opacity: cfg.tooltip_opacity,
+        maxColumnPx: cfg.tooltip_max_column_px,
+    };
+}
+
+export const NUMERIC_RE =
+    /^[-+−]?[$€£¥]?\s?\d[\d.,  \s]*(?:[eE][-+]?\d+|[KMB%])?$/;
+
+export const TOOLTIP_ROW_HEIGHT = 16;
+export const TOOLTIP_PADDING = 8;
+export const TOOLTIP_COL_GAP = 8;
+
+export interface MeasuredTooltipGrid {
+    rows: string[][];
+
+    colWidths: number[];
+
+    colRightAlign: boolean[];
+
+    boxW: number;
+    boxH: number;
+}
+
+/**
+ * Measure a tooltip grid under the current `ctx.font`.
+ */
+export function measureTooltipGrid(
+    ctx: Context2D,
+    grid: TooltipContent,
+    maxColumnPx: number,
+): MeasuredTooltipGrid {
+    const spanCap = maxColumnPx * 2 + TOOLTIP_COL_GAP;
+    const colWidths: number[] = [];
+    const colNumeric: boolean[] = [];
+    const rows: string[][] = [];
+    let spanWidth = 0;
+
+    for (const row of grid) {
+        if (row.length <= 1) {
+            const text = ellipsize(ctx, row[0] ?? "", spanCap);
+            rows.push([text]);
+            spanWidth = Math.max(spanWidth, ctx.measureText(text).width);
+            continue;
+        }
+
+        const cells: string[] = [];
+        for (let j = 0; j < row.length; j++) {
+            const original = row[j] ?? "";
+            const text = ellipsize(ctx, original, maxColumnPx);
+            cells.push(text);
+            colWidths[j] = Math.max(
+                colWidths[j] ?? 0,
+                ctx.measureText(text).width,
+            );
+            if (j >= 1 && original !== "") {
+                const numeric = NUMERIC_RE.test(original);
+                colNumeric[j] =
+                    colNumeric[j] === undefined
+                        ? numeric
+                        : colNumeric[j] && numeric;
+            }
+        }
+
+        rows.push(cells);
+    }
+
+    let columnsWidth = 0;
+    for (let j = 0; j < colWidths.length; j++) {
+        columnsWidth += colWidths[j] + (j > 0 ? TOOLTIP_COL_GAP : 0);
+    }
+
+    const innerW = Math.max(spanWidth, columnsWidth);
+    return {
+        rows,
+        colWidths,
+        colRightAlign: colWidths.map(
+            (_, j) => (colNumeric[j] ?? false) && j >= 1,
+        ),
+        boxW: innerW + TOOLTIP_PADDING * 2,
+        boxH: grid.length * TOOLTIP_ROW_HEIGHT + TOOLTIP_PADDING * 2 - 4,
+    };
+}
+
+/**
+ * Paint a measured tooltip grid at `(tx, ty)`.
+ */
+export function paintTooltipGrid(
+    ctx: Context2D,
+    measured: MeasuredTooltipGrid,
+    tx: number,
+    ty: number,
+    theme: Theme,
+    opacity: number,
+): void {
+    const { rows, colWidths, colRightAlign, boxW, boxH } = measured;
+
+    ctx.globalAlpha = Math.min(1, Math.max(0, opacity));
+    ctx.fillStyle = theme.tooltipBg;
+    ctx.strokeStyle = theme.tooltipBorder;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.rect(tx, ty, boxW, boxH);
+    ctx.fill();
+    ctx.stroke();
+    ctx.globalAlpha = 1.0;
+
+    ctx.fillStyle = theme.tooltipText;
+    ctx.textBaseline = "top";
+    for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+        const rowY = ty + TOOLTIP_PADDING + i * TOOLTIP_ROW_HEIGHT;
+        if (row.length <= 1) {
+            ctx.textAlign = "left";
+            ctx.fillText(row[0], tx + TOOLTIP_PADDING, rowY);
+            continue;
+        }
+
+        let colX = tx + TOOLTIP_PADDING;
+        for (let j = 0; j < row.length; j++) {
+            const width = colWidths[j] ?? 0;
+            if (colRightAlign[j]) {
+                ctx.textAlign = "right";
+                ctx.fillText(row[j], colX + width, rowY);
+            } else {
+                ctx.textAlign = "left";
+                ctx.fillText(row[j], colX, rowY);
+            }
+
+            colX += width + TOOLTIP_COL_GAP;
+        }
+    }
+
+    ctx.textAlign = "left";
+}
+
+export function ellipsize(ctx: Context2D, text: string, maxW: number): string {
+    if (ctx.measureText(text).width <= maxW) {
+        return text;
+    }
+
+    let lo = 0;
+    let hi = text.length;
+    while (lo < hi) {
+        const mid = (lo + hi + 1) >> 1;
+        if (ctx.measureText(text.slice(0, mid) + "…").width <= maxW) {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+
+    return text.slice(0, lo) + "…";
+}

--- a/packages/viewer-charts/src/ts/layout/ticks.ts
+++ b/packages/viewer-charts/src/ts/layout/ticks.ts
@@ -69,6 +69,18 @@ export function computeNiceTicks(
     return ticks;
 }
 
+export function stepTickFormatter(
+    isDate: boolean | undefined,
+    ticks: number[] | null | undefined,
+): (v: number) => string {
+    if (!isDate) {
+        return formatTickValue;
+    }
+
+    const step = ticks && ticks.length > 1 ? ticks[1] - ticks[0] : 0;
+    return (v: number) => formatDateTickValue(v, step);
+}
+
 /**
  * Format a numeric tick value for display.
  * Uses K/M/B suffixes for large numbers, fixed decimals for small.

--- a/packages/viewer-charts/src/ts/plugin/charts.ts
+++ b/packages/viewer-charts/src/ts/plugin/charts.ts
@@ -100,7 +100,9 @@ const DEFAULT_MAX_COLUMNS = 10_000;
 
 //  Plugin-config field sets, by chart family.
 //
-const LEGEND_FIELDS: readonly PluginConfigField[] = [
+//  Exported for `plugin.ts`'s `PLUGIN_FIELD_GROUPS`, which sections the
+//  legend knobs into one collapsible group across every family.
+export const LEGEND_FIELDS: readonly PluginConfigField[] = [
     "legend_mode",
     "legend_size_mode",
     "legend_width_px",

--- a/packages/viewer-charts/src/ts/plugin/charts.ts
+++ b/packages/viewer-charts/src/ts/plugin/charts.ts
@@ -100,8 +100,6 @@ const DEFAULT_MAX_COLUMNS = 10_000;
 
 //  Plugin-config field sets, by chart family.
 //
-//  Exported for `plugin.ts`'s `PLUGIN_FIELD_GROUPS`, which sections the
-//  legend knobs into one collapsible group across every family.
 export const LEGEND_FIELDS: readonly PluginConfigField[] = [
     "legend_mode",
     "legend_size_mode",
@@ -111,6 +109,11 @@ export const LEGEND_FIELDS: readonly PluginConfigField[] = [
     "legend_x",
     "legend_y",
     "legend_opacity",
+];
+
+export const TOOLTIP_FIELDS: readonly PluginConfigField[] = [
+    "tooltip_max_column_px",
+    "tooltip_opacity",
 ];
 
 // Series charts paint bars / lines / scatter / area glyphs (selected
@@ -127,6 +130,7 @@ const SERIES_FIELDS: readonly PluginConfigField[] = [
     "band_inner_frac",
     "bar_inner_pad",
     ...LEGEND_FIELDS,
+    ...TOOLTIP_FIELDS,
 ];
 
 // The band pipeline's historical split_by rendering is a single plot
@@ -152,6 +156,7 @@ const CARTESIAN_FIELDS: readonly PluginConfigField[] = [
     "line_width_px",
     "point_size_px",
     ...LEGEND_FIELDS,
+    ...TOOLTIP_FIELDS,
 ];
 
 // Candlestick/OHLC share the categorical-X build pipeline (band slots)
@@ -164,14 +169,19 @@ const FIN_FIELDS: readonly PluginConfigField[] = [
     "bar_inner_pad",
     "wick_width_px",
     "ohlc_line_width_px",
+    ...TOOLTIP_FIELDS,
 ];
 
-const TREE_FIELDS: readonly PluginConfigField[] = [...LEGEND_FIELDS];
+const TREE_FIELDS: readonly PluginConfigField[] = [
+    ...LEGEND_FIELDS,
+    ...TOOLTIP_FIELDS,
+];
 
 // Heatmap
 const HEATMAP_FIELDS: readonly PluginConfigField[] = [
     "facet_zoom_mode",
     ...LEGEND_FIELDS,
+    ...TOOLTIP_FIELDS,
 ];
 
 // Map — reuses the cartesian build pipeline with a Mercator
@@ -187,6 +197,7 @@ const MAP_BASE_FIELDS: readonly PluginConfigField[] = [
     "map_tile_alpha",
     "numeric_axes",
     ...LEGEND_FIELDS,
+    ...TOOLTIP_FIELDS,
 ];
 const MAP_SCATTER_FIELDS: readonly PluginConfigField[] = [
     ...MAP_BASE_FIELDS,
@@ -217,6 +228,7 @@ const DENSITY_FIELDS: readonly PluginConfigField[] = [
     "gradient_intensity",
     "gradient_heat_max",
     ...LEGEND_FIELDS,
+    ...TOOLTIP_FIELDS,
 ];
 
 function make(

--- a/packages/viewer-charts/src/ts/plugin/format-defaults.ts
+++ b/packages/viewer-charts/src/ts/plugin/format-defaults.ts
@@ -10,46 +10,28 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-use strum::{Display, EnumIter};
+import type {
+    DateFormatConfig,
+    NumberFormatConfig,
+} from "@perspective-dev/viewer/src/ts/column-format.js";
 
-use crate::config::{Notation, NumberFormatStyle};
+/**
+ * The chart plugin's default per-column formats, declared to the viewer in
+ * `column_config_schema()` and applied by the render path under sparse or
+ * absent configs.
+ */
+export const CHART_NUMBER_DEFAULTS: NumberFormatConfig = {
+    notation: "compact",
+    compactDisplay: "short",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+};
 
-#[derive(Clone, PartialEq, Debug, Copy, Default, EnumIter, Display)]
-pub enum NumberStyle {
-    #[default]
-    Decimal,
-    Percent,
-    Currency,
-    Unit,
-}
+export const CHART_DATETIME_DEFAULTS: DateFormatConfig = {
+    dateStyle: "medium",
+    timeStyle: "disabled",
+};
 
-impl From<&NumberFormatStyle> for NumberStyle {
-    fn from(style: &NumberFormatStyle) -> Self {
-        match style {
-            NumberFormatStyle::Decimal => Self::Decimal,
-            NumberFormatStyle::Currency(_) => Self::Currency,
-            NumberFormatStyle::Percent => Self::Percent,
-            NumberFormatStyle::Unit(_) => Self::Unit,
-        }
-    }
-}
-
-#[derive(Clone, PartialEq, Debug, Copy, Default, Display, EnumIter)]
-pub enum NotationName {
-    #[default]
-    Standard,
-    Scientific,
-    Engineering,
-    Compact,
-}
-
-impl From<&Notation> for NotationName {
-    fn from(notation: &Notation) -> Self {
-        match notation {
-            Notation::Standard => Self::Standard,
-            Notation::Scientific => Self::Scientific,
-            Notation::Engineering => Self::Engineering,
-            Notation::Compact(_) => Self::Compact,
-        }
-    }
-}
+export const CHART_DATE_DEFAULTS: DateFormatConfig = {
+    dateStyle: "medium",
+};

--- a/packages/viewer-charts/src/ts/plugin/plugin.ts
+++ b/packages/viewer-charts/src/ts/plugin/plugin.ts
@@ -17,7 +17,12 @@ import type {
     IPerspectiveViewerPlugin,
     PluginStaticConfig,
 } from "@perspective-dev/viewer";
-import { ChartTypeConfig, LEGEND_FIELDS, PluginConfigField } from "./charts";
+import {
+    ChartTypeConfig,
+    LEGEND_FIELDS,
+    TOOLTIP_FIELDS,
+    PluginConfigField,
+} from "./charts";
 import style from "../../css/perspective-viewer-charts.css";
 import {
     DEFAULT_FACET_CONFIG,
@@ -175,6 +180,8 @@ const FIELD_SCHEMAS: Record<PluginConfigField, FieldSpec | (() => FieldSpec)> =
         legend_x: { kind: "Number", min: 0, max: 1, step: 0.01 },
         legend_y: { kind: "Number", min: 0, max: 1, step: 0.01 },
         legend_opacity: { kind: "Number", min: 0, max: 1, step: 0.05 },
+        tooltip_max_column_px: { kind: "Number", min: 40, max: 512, step: 1 },
+        tooltip_opacity: { kind: "Number", min: 0, max: 1, step: 0.05 },
     };
 
 function fieldSpec(
@@ -186,18 +193,6 @@ function fieldSpec(
     return { ...spec, key, default: defaults[key] };
 }
 
-/**
- * Presentation-only sectioning of the plugin-config controls, applied by
- * `plugin_config_schema()` over each chart type's flat
- * `applicable_plugin_fields`. Groups render in the host's Plugin tab as
- * default-open collapsible sections and never appear in `save()` output —
- * the host flattens them for all key-level logic. Group `key`s resolve
- * their visible header via `--psp-label--group-<key>--content`.
- *
- * Order is meaningful twice over: groups emit in this array's order
- * (after any ungrouped fields), and each group's members emit in its
- * `fields` order.
- */
 const PLUGIN_FIELD_GROUPS: ReadonlyArray<{
     key: string;
     fields: readonly PluginConfigField[];
@@ -237,6 +232,7 @@ const PLUGIN_FIELD_GROUPS: ReadonlyArray<{
     },
     { key: "basemap", fields: ["map_tile_provider", "map_tile_alpha"] },
     { key: "legend", fields: LEGEND_FIELDS },
+    { key: "tooltip", fields: TOOLTIP_FIELDS },
 ];
 
 const GLOBAL_STYLES = (() => {
@@ -744,8 +740,6 @@ export class HTMLPerspectiveViewerWebGLPluginElement
         const applicable = this._chartType.applicable_plugin_fields;
         const present = new Set(applicable);
 
-        // A group needs >= 2 applicable members to earn a section — a
-        // one-item collapsible is noise, so lone members emit flat.
         const grouped = new Set<PluginConfigField>();
         const groups: Array<Record<string, unknown> & { kind: string }> = [];
         for (const group of PLUGIN_FIELD_GROUPS) {

--- a/packages/viewer-charts/src/ts/plugin/plugin.ts
+++ b/packages/viewer-charts/src/ts/plugin/plugin.ts
@@ -30,6 +30,11 @@ import {
     type FacetConfig,
     type PluginConfig,
 } from "../charts/chart";
+import {
+    CHART_DATE_DEFAULTS,
+    CHART_DATETIME_DEFAULTS,
+    CHART_NUMBER_DEFAULTS,
+} from "./format-defaults";
 import { RawEventForwarder } from "../interaction/raw-event-forwarder";
 import { RendererTransport } from "../transport/renderer-transport";
 import { TILE_SOURCES, type TileSourceSpec } from "../map/tile-source";
@@ -724,9 +729,20 @@ export class HTMLPerspectiveViewerWebGLPluginElement
         // Per-column formatter widgets. Surfaced for every chart type so
         // axes / tooltips / legends honor the user's format choice.
         if (column_type === "integer" || column_type === "float") {
-            fields.push({ kind: "NumberFormat" });
-        } else if (column_type === "date" || column_type === "datetime") {
-            fields.push({ kind: "DatetimeFormat" });
+            fields.push({
+                kind: "NumberFormat",
+                default: CHART_NUMBER_DEFAULTS,
+            });
+        } else if (column_type === "datetime") {
+            fields.push({
+                kind: "DatetimeFormat",
+                default: CHART_DATETIME_DEFAULTS,
+            });
+        } else if (column_type === "date") {
+            fields.push({
+                kind: "DatetimeFormat",
+                default: CHART_DATE_DEFAULTS,
+            });
         }
 
         return { fields };

--- a/packages/viewer-charts/src/ts/plugin/plugin.ts
+++ b/packages/viewer-charts/src/ts/plugin/plugin.ts
@@ -17,7 +17,7 @@ import type {
     IPerspectiveViewerPlugin,
     PluginStaticConfig,
 } from "@perspective-dev/viewer";
-import { ChartTypeConfig, PluginConfigField } from "./charts";
+import { ChartTypeConfig, LEGEND_FIELDS, PluginConfigField } from "./charts";
 import style from "../../css/perspective-viewer-charts.css";
 import {
     DEFAULT_FACET_CONFIG,
@@ -185,6 +185,59 @@ function fieldSpec(
     const spec = typeof entry === "function" ? entry() : entry;
     return { ...spec, key, default: defaults[key] };
 }
+
+/**
+ * Presentation-only sectioning of the plugin-config controls, applied by
+ * `plugin_config_schema()` over each chart type's flat
+ * `applicable_plugin_fields`. Groups render in the host's Plugin tab as
+ * default-open collapsible sections and never appear in `save()` output —
+ * the host flattens them for all key-level logic. Group `key`s resolve
+ * their visible header via `--psp-label--group-<key>--content`.
+ *
+ * Order is meaningful twice over: groups emit in this array's order
+ * (after any ungrouped fields), and each group's members emit in its
+ * `fields` order.
+ */
+const PLUGIN_FIELD_GROUPS: ReadonlyArray<{
+    key: string;
+    fields: readonly PluginConfigField[];
+}> = [
+    {
+        key: "axes",
+        fields: [
+            "auto_alt_y_axis",
+            "include_zero",
+            "domain_mode",
+            "numeric_axes",
+        ],
+    },
+    {
+        key: "facets",
+        fields: ["facet_mode", "facet_zoom_mode", "series_zoom_mode"],
+    },
+    {
+        key: "glyph",
+        fields: [
+            "line_width_px",
+            "point_size_px",
+            "band_inner_frac",
+            "bar_inner_pad",
+            "wick_width_px",
+            "ohlc_line_width_px",
+        ],
+    },
+    {
+        key: "density",
+        fields: [
+            "gradient_color_mode",
+            "gradient_radius_px",
+            "gradient_intensity",
+            "gradient_heat_max",
+        ],
+    },
+    { key: "basemap", fields: ["map_tile_provider", "map_tile_alpha"] },
+    { key: "legend", fields: LEGEND_FIELDS },
+];
 
 const GLOBAL_STYLES = (() => {
     const sheet = new CSSStyleSheet();
@@ -688,11 +741,34 @@ export class HTMLPerspectiveViewerWebGLPluginElement
         group_rollup_mode?: string;
     }) {
         const defaults = this._effectiveDefaults();
-        const fields = this._chartType.applicable_plugin_fields.map((key) =>
-            fieldSpec(key, defaults),
-        );
+        const applicable = this._chartType.applicable_plugin_fields;
+        const present = new Set(applicable);
 
-        return { fields };
+        // A group needs >= 2 applicable members to earn a section — a
+        // one-item collapsible is noise, so lone members emit flat.
+        const grouped = new Set<PluginConfigField>();
+        const groups: Array<Record<string, unknown> & { kind: string }> = [];
+        for (const group of PLUGIN_FIELD_GROUPS) {
+            const members = group.fields.filter((k) => present.has(k));
+            if (members.length >= 1) {
+                for (const k of members) {
+                    grouped.add(k);
+                }
+
+                groups.push({
+                    kind: "Group",
+                    key: group.key,
+                    fields: members.map((k) => fieldSpec(k, defaults)),
+                });
+            }
+        }
+
+        const fields: Array<Record<string, unknown> & { kind: string }> =
+            applicable
+                .filter((k) => !grouped.has(k))
+                .map((k) => fieldSpec(k, defaults));
+
+        return { fields: [...fields, ...groups] };
     }
 
     private _resolvedTheme(): Theme {

--- a/packages/viewer-charts/src/ts/transport/protocol.ts
+++ b/packages/viewer-charts/src/ts/transport/protocol.ts
@@ -508,7 +508,9 @@ export interface ErrorMsg {
  */
 export interface PinTooltipMsg {
     kind: "pinTooltip";
-    lines: string[];
+
+    grid: string[][];
+    style: { opacity: number; maxColumnPx: number };
     pos: { px: number; py: number };
     bounds: { cssWidth: number; cssHeight: number };
 }

--- a/packages/viewer-charts/src/ts/transport/renderer-transport.ts
+++ b/packages/viewer-charts/src/ts/transport/renderer-transport.ts
@@ -14,6 +14,7 @@ import type { Client, View, ViewConfig } from "@perspective-dev/client";
 import type { FacetConfig, PluginConfig } from "../charts/chart";
 import type {
     ControlMsg,
+    ErrorMsg,
     InitMsg,
     InteractionEvent,
     LoadAndRenderMsg,
@@ -73,6 +74,24 @@ async function getSharedWorker(): Promise<Worker> {
             const env = e.data as WorkerEnvelope;
             HOST_LISTENERS.get(env.sessionId)?.(env.msg);
         });
+
+        let poisoned = false;
+        w.addEventListener("error", (event: ErrorEvent) => {
+            if (poisoned) {
+                return;
+            }
+
+            poisoned = true;
+            SHARED_WORKER = null;
+            const detail = event.message || `failed to load ${url}`;
+            const message = `perspective-viewer-charts renderer worker error: ${detail}`;
+            console.error(message, event.error ?? "");
+            const errorMsg: ErrorMsg = { kind: "error", message };
+            for (const listener of HOST_LISTENERS.values()) {
+                listener(errorMsg);
+            }
+        });
+
         return w;
     })();
 
@@ -823,7 +842,12 @@ export class RendererTransport {
                 this._resolvePending(msg.requestId, "saveZoom", msg.state);
                 break;
             case "pinTooltip":
-                this._ensureHostSink()?.pin(msg.lines, msg.pos, msg.bounds);
+                this._ensureHostSink()?.pin(
+                    msg.grid,
+                    msg.pos,
+                    msg.bounds,
+                    msg.style,
+                );
                 break;
             case "dismissTooltip":
                 this._hostSink?.dismiss();

--- a/packages/viewer-charts/test/ts/control-groups.spec.ts
+++ b/packages/viewer-charts/test/ts/control-groups.spec.ts
@@ -1,0 +1,125 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+// `plugin_config_schema()` partitions each chart family's flat
+// `applicable_plugin_fields` through `PLUGIN_FIELD_GROUPS` into
+// presentation-only `ControlSpec::Group` sections (axes / facets / glyph
+// / density / basemap / legend). A group needs >= 2 applicable members;
+// lone members emit flat. Grouping must never leak into `save()` output —
+// `plugin_config` keys stay flat.
+
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "@perspective-dev/test";
+import { gotoBasic, restoreChart } from "./helpers";
+
+async function openPluginTab(page: Page): Promise<Locator> {
+    await page.locator("perspective-viewer #plugin_tabbar_tab").click();
+    const tab = page.locator("perspective-viewer #plugin-tab");
+    await tab.waitFor({ state: "visible" });
+    return tab;
+}
+
+test.describe("Charts plugin-config control groups", () => {
+    test.beforeEach(async ({ page }) => {
+        await gotoBasic(page);
+    });
+
+    test("Y Bar partitions every field into 4 default-open groups", async ({
+        page,
+    }) => {
+        await restoreChart(page, {
+            plugin: "Y Bar",
+            columns: ["Profit"],
+            group_by: ["State"],
+            settings: true,
+        });
+
+        const tab = await openPluginTab(page);
+        const groups = tab.locator("details.control-group");
+
+        // Series family: axes(3) / facets(2) / glyph(4) / legend(8),
+        // nothing flat.
+        await expect(groups).toHaveCount(4);
+        for (const key of ["axes", "facets", "glyph", "legend"]) {
+            const group = tab.locator("details.control-group", {
+                has: page.locator(`#${key}-group-label`),
+            });
+            await expect(group).toHaveCount(1);
+            await expect(group).toHaveJSProperty("open", true);
+        }
+
+        await expect(
+            tab.locator("#plugin-config-container > fieldset.style-control"),
+        ).toHaveCount(0);
+        await expect(
+            tab.locator("details.control-group #legend_mode-label"),
+        ).toHaveCount(1);
+        await expect(
+            tab.locator("details.control-group #include_zero-label"),
+        ).toHaveCount(1);
+    });
+
+    test("lone group members emit flat (X/Y Scatter domain_mode)", async ({
+        page,
+    }) => {
+        await restoreChart(page, {
+            plugin: "X/Y Scatter",
+            columns: ["Sales", "Profit"],
+            settings: true,
+        });
+
+        const tab = await openPluginTab(page);
+
+        // Cartesian family: facets(2) / glyph(2) / legend(8) group, but
+        // `domain_mode` is the only applicable "axes" member so it
+        // renders flat.
+        await expect(tab.locator("details.control-group")).toHaveCount(3);
+        await expect(
+            tab.locator(
+                "#plugin-config-container > fieldset.style-control #domain_mode-label",
+            ),
+        ).toHaveCount(1);
+        await expect(
+            tab.locator("details.control-group #domain_mode-label"),
+        ).toHaveCount(0);
+    });
+
+    test("grouped fields serialize flat in save()", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "Y Bar",
+            columns: ["Profit"],
+            group_by: ["State"],
+            settings: true,
+            plugin_config: { legend_mode: "sidebar", line_width_px: 4 },
+        });
+
+        const config = await page.evaluate(async () => {
+            const viewer = document.querySelector("perspective-viewer")!;
+            return (await viewer.save()) as any;
+        });
+
+        expect(config.plugin_config.legend_mode).toEqual("sidebar");
+        expect(config.plugin_config.line_width_px).toEqual(4);
+
+        // No group key may appear in serialized output.
+        for (const key of [
+            "axes",
+            "facets",
+            "glyph",
+            "density",
+            "basemap",
+            "legend",
+        ]) {
+            expect(config.plugin_config[key]).toBeUndefined();
+        }
+    });
+});

--- a/packages/viewer-charts/test/ts/control-groups.spec.ts
+++ b/packages/viewer-charts/test/ts/control-groups.spec.ts
@@ -10,13 +10,6 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-// `plugin_config_schema()` partitions each chart family's flat
-// `applicable_plugin_fields` through `PLUGIN_FIELD_GROUPS` into
-// presentation-only `ControlSpec::Group` sections (axes / facets / glyph
-// / density / basemap / legend). A group needs >= 2 applicable members;
-// lone members emit flat. Grouping must never leak into `save()` output —
-// `plugin_config` keys stay flat.
-
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@perspective-dev/test";
 import { gotoBasic, restoreChart } from "./helpers";
@@ -33,7 +26,7 @@ test.describe("Charts plugin-config control groups", () => {
         await gotoBasic(page);
     });
 
-    test("Y Bar partitions every field into 4 default-open groups", async ({
+    test("Y Bar partitions every field into 5 default-open groups", async ({
         page,
     }) => {
         await restoreChart(page, {
@@ -45,11 +38,8 @@ test.describe("Charts plugin-config control groups", () => {
 
         const tab = await openPluginTab(page);
         const groups = tab.locator("details.control-group");
-
-        // Series family: axes(3) / facets(2) / glyph(4) / legend(8),
-        // nothing flat.
-        await expect(groups).toHaveCount(4);
-        for (const key of ["axes", "facets", "glyph", "legend"]) {
+        await expect(groups).toHaveCount(5);
+        for (const key of ["axes", "facets", "glyph", "legend", "tooltip"]) {
             const group = tab.locator("details.control-group", {
                 has: page.locator(`#${key}-group-label`),
             });
@@ -68,31 +58,6 @@ test.describe("Charts plugin-config control groups", () => {
         ).toHaveCount(1);
     });
 
-    test("lone group members emit flat (X/Y Scatter domain_mode)", async ({
-        page,
-    }) => {
-        await restoreChart(page, {
-            plugin: "X/Y Scatter",
-            columns: ["Sales", "Profit"],
-            settings: true,
-        });
-
-        const tab = await openPluginTab(page);
-
-        // Cartesian family: facets(2) / glyph(2) / legend(8) group, but
-        // `domain_mode` is the only applicable "axes" member so it
-        // renders flat.
-        await expect(tab.locator("details.control-group")).toHaveCount(3);
-        await expect(
-            tab.locator(
-                "#plugin-config-container > fieldset.style-control #domain_mode-label",
-            ),
-        ).toHaveCount(1);
-        await expect(
-            tab.locator("details.control-group #domain_mode-label"),
-        ).toHaveCount(0);
-    });
-
     test("grouped fields serialize flat in save()", async ({ page }) => {
         await restoreChart(page, {
             plugin: "Y Bar",
@@ -109,8 +74,6 @@ test.describe("Charts plugin-config control groups", () => {
 
         expect(config.plugin_config.legend_mode).toEqual("sidebar");
         expect(config.plugin_config.line_width_px).toEqual(4);
-
-        // No group key may appear in serialized output.
         for (const key of [
             "axes",
             "facets",

--- a/packages/viewer-charts/test/ts/facet-mode.spec.ts
+++ b/packages/viewer-charts/test/ts/facet-mode.spec.ts
@@ -46,10 +46,19 @@ async function schemaFields(
         const viewer = document.querySelector("perspective-viewer")!;
         const plugin = await (viewer as any).getPlugin();
         const schema = plugin.plugin_config_schema?.() ?? { fields: [] };
-        return schema.fields.map((f: { key: string; default?: unknown }) => ({
-            key: f.key,
-            default: f.default,
-        }));
+        const flat: { key: string; default?: unknown }[] = [];
+        const walk = (fields: any[]) => {
+            for (const f of fields) {
+                if (f.kind === "Group") {
+                    walk(f.fields);
+                } else {
+                    flat.push({ key: f.key, default: f.default });
+                }
+            }
+        };
+
+        walk(schema.fields);
+        return flat;
     });
 }
 

--- a/packages/viewer-charts/test/ts/legend-mode.spec.ts
+++ b/packages/viewer-charts/test/ts/legend-mode.spec.ts
@@ -193,9 +193,13 @@ test.describe("legend_mode", () => {
         const defaults = await page.evaluate(() => {
             const modeDefault = (tag: string) => {
                 const el = document.createElement(tag) as any;
-                return el
-                    .plugin_config_schema()
-                    .fields.find((f: any) => f.key === "legend_mode")?.default;
+                const flat: any[] = [];
+                const walk = (fields: any[]) =>
+                    fields.forEach((f) =>
+                        f.kind === "Group" ? walk(f.fields) : flat.push(f),
+                    );
+                walk(el.plugin_config_schema().fields);
+                return flat.find((f) => f.key === "legend_mode")?.default;
             };
 
             return {
@@ -533,9 +537,13 @@ test.describe("legend_size_mode", () => {
             const el = document.createElement(
                 "perspective-viewer-charts-y-line",
             ) as any;
-            return el
-                .plugin_config_schema()
-                .fields.find((f: any) => f.key === "legend_size_mode")?.default;
+            const flat: any[] = [];
+            const walk = (fields: any[]) =>
+                fields.forEach((f) =>
+                    f.kind === "Group" ? walk(f.fields) : flat.push(f),
+                );
+            walk(el.plugin_config_schema().fields);
+            return flat.find((f) => f.key === "legend_size_mode")?.default;
         });
         expect(schemaDefault).toBe("auto");
 

--- a/packages/viewer-charts/test/ts/map-tile-sources.spec.ts
+++ b/packages/viewer-charts/test/ts/map-tile-sources.spec.ts
@@ -68,9 +68,13 @@ test.describe("map tile sources", () => {
                 "perspective-viewer-charts-map-scatter",
             ) as any;
             const schema = el.plugin_config_schema();
-            const field = schema.fields.find(
-                (f: any) => f.key === "map_tile_provider",
-            );
+            const flat: any[] = [];
+            const walk = (fields: any[]) =>
+                fields.forEach((f) =>
+                    f.kind === "Group" ? walk(f.fields) : flat.push(f),
+                );
+            walk(schema.fields);
+            const field = flat.find((f) => f.key === "map_tile_provider");
             return {
                 ids: cls.tileSources().map((s: any) => s.id),
                 variants: field?.variants ?? [],
@@ -121,9 +125,13 @@ test.describe("map tile sources", () => {
             const el = document.createElement(
                 "perspective-viewer-charts-map-scatter",
             ) as any;
-            const field = el
-                .plugin_config_schema()
-                .fields.find((f: any) => f.key === "map_tile_provider");
+            const flat: any[] = [];
+            const walk = (fields: any[]) =>
+                fields.forEach((f) =>
+                    f.kind === "Group" ? walk(f.fields) : flat.push(f),
+                );
+            walk(el.plugin_config_schema().fields);
+            const field = flat.find((f) => f.key === "map_tile_provider");
             return field.variants.map((v: any) => v.value);
         });
         expect(variants).toContain("test-red");

--- a/packages/viewer-charts/test/ts/snapshot/axis-indicators.spec.ts
+++ b/packages/viewer-charts/test/ts/snapshot/axis-indicators.spec.ts
@@ -1,0 +1,160 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { test } from "@perspective-dev/test";
+import { expectViewerScreenshot, gotoBasic, restoreChart } from "../helpers";
+import { MAP_CONFIG, registerColorSources } from "../map-helpers";
+
+const PLOT_CX = 640;
+const PLOT_CY = 360;
+const SETTLE_MS = 200;
+
+async function hoverAndSnapshot(
+    page: import("@playwright/test").Page,
+    x = PLOT_CX,
+    y = PLOT_CY,
+): Promise<void> {
+    await page.mouse.move(x, y);
+    await page.waitForTimeout(SETTLE_MS);
+    await expectViewerScreenshot(page);
+}
+
+test.describe("Axis hover indicators", () => {
+    test.beforeEach(async ({ page }) => {
+        await gotoBasic(page);
+    });
+
+    test("scatter paints trace lines and axis badges", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "X/Y Scatter",
+            columns: ["Quantity", "Profit"],
+        });
+        await hoverAndSnapshot(page);
+    });
+
+    test("scatter badge uses configured number_format", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "X/Y Scatter",
+            columns: ["Quantity", "Profit"],
+            columns_config: {
+                Profit: {
+                    number_format: { style: "currency", currency: "USD" },
+                },
+            },
+        } as never);
+        await hoverAndSnapshot(page);
+    });
+
+    test("line badge uses configured date_format", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "X/Y Line",
+            columns: ["Order Date", "Profit"],
+            group_by: ["Order Date"],
+            columns_config: {
+                "Order Date": {
+                    date_format: { dateStyle: "full", timeStyle: "disabled" },
+                },
+            },
+        } as never);
+        await hoverAndSnapshot(page);
+    });
+
+    test("y-bar paints category and value badges", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "Y Bar",
+            columns: ["Sales"],
+            group_by: ["Category"],
+        });
+        await hoverAndSnapshot(page);
+    });
+
+    test("alt_axis value badge lands on the right axis", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "Y Bar",
+            columns: ["Discount", "Sales"],
+            group_by: ["Category"],
+            columns_config: { Sales: { alt_axis: true } },
+        } as never);
+        await hoverAndSnapshot(page);
+    });
+
+    test("x-bar flips indicator orientation", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "X Bar",
+            columns: ["Sales"],
+            group_by: ["Category"],
+        });
+        await hoverAndSnapshot(page);
+    });
+
+    test("candlestick anchors the value badge at close", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "Candlestick",
+            columns: ["Sales", "Profit", "Quantity", "Discount"],
+            group_by: ["Order Date"],
+        });
+        await hoverAndSnapshot(page);
+    });
+
+    test("heatmap snaps indicators to the cell center", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "Heatmap",
+            columns: ["Sales"],
+            group_by: ["Region"],
+            split_by: ["Category"],
+        });
+        await hoverAndSnapshot(page);
+    });
+
+    test("faceted scatter badges only in the source cell", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "X/Y Scatter",
+            columns: ["Quantity", "Profit"],
+            split_by: ["Region"],
+            plugin_config: { facet_mode: "grid" },
+        } as never);
+        await hoverAndSnapshot(page, 400, 250);
+    });
+
+    test("map with degree axes paints degree badges", async ({ page }) => {
+        await registerColorSources(page, [{ id: "test-red", color: "#f00" }]);
+        await restoreChart(page, {
+            ...MAP_CONFIG,
+            plugin_config: { map_tile_provider: "test-red" },
+        } as never);
+        await hoverAndSnapshot(page);
+    });
+
+    test("bare map keeps the crosshair without badges", async ({ page }) => {
+        await registerColorSources(page, [{ id: "test-red", color: "#f00" }]);
+        await restoreChart(page, {
+            ...MAP_CONFIG,
+            plugin_config: {
+                map_tile_provider: "test-red",
+                numeric_axes: false,
+            },
+        } as never);
+        await hoverAndSnapshot(page);
+    });
+
+    test("indicators persist while pinned", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "X/Y Scatter",
+            columns: ["Quantity", "Profit"],
+        });
+        await page.mouse.move(PLOT_CX, PLOT_CY);
+        await page.waitForTimeout(SETTLE_MS);
+        await page.mouse.click(PLOT_CX, PLOT_CY);
+        await page.waitForTimeout(SETTLE_MS);
+        await expectViewerScreenshot(page);
+    });
+});

--- a/packages/viewer-charts/test/ts/snapshot/tooltip-grid.spec.ts
+++ b/packages/viewer-charts/test/ts/snapshot/tooltip-grid.spec.ts
@@ -1,0 +1,147 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { expect, test } from "@perspective-dev/test";
+import { expectViewerScreenshot, gotoBasic, restoreChart } from "../helpers";
+import { savedPluginConfig } from "../map-helpers";
+
+const PLOT_CX = 640;
+const PLOT_CY = 360;
+const SETTLE_MS = 200;
+
+async function hoverAndSnapshot(
+    page: import("@playwright/test").Page,
+    x = PLOT_CX,
+    y = PLOT_CY,
+): Promise<void> {
+    await page.mouse.move(x, y);
+    await page.waitForTimeout(SETTLE_MS);
+    await expectViewerScreenshot(page);
+}
+
+test.describe("Tooltip grid", () => {
+    test.beforeEach(async ({ page }) => {
+        await gotoBasic(page);
+    });
+
+    test("scatter hover renders two-column grid", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "X/Y Scatter",
+            columns: ["Quantity", "Profit"],
+        });
+        await hoverAndSnapshot(page);
+    });
+
+    test("y-bar hover renders category span and value columns", async ({
+        page,
+    }) => {
+        await restoreChart(page, {
+            plugin: "Y Bar",
+            columns: ["Sales"],
+            group_by: ["Category"],
+            split_by: ["Region"],
+        });
+        await hoverAndSnapshot(page);
+    });
+
+    test("candlestick hover renders OHLC rows right-aligned", async ({
+        page,
+    }) => {
+        await restoreChart(page, {
+            plugin: "Candlestick",
+            columns: ["Sales", "Profit", "Quantity", "Discount"],
+            group_by: ["Order Date"],
+        });
+        await hoverAndSnapshot(page);
+    });
+
+    test("treemap hover renders path span and value rows", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "Treemap",
+            columns: ["Sales"],
+            group_by: ["Category", "Sub-Category"],
+        });
+        await hoverAndSnapshot(page);
+    });
+
+    test("tooltip_max_column_px truncates wide cells", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "X/Y Scatter",
+            columns: ["Quantity", "Profit"],
+            plugin_config: { tooltip_max_column_px: 60 },
+        } as never);
+        await hoverAndSnapshot(page);
+    });
+
+    test("tooltip_opacity renders translucent chrome", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "X/Y Scatter",
+            columns: ["Quantity", "Profit"],
+            plugin_config: { tooltip_opacity: 0.5 },
+        } as never);
+        await hoverAndSnapshot(page);
+    });
+
+    test("pinned tooltip renders DOM grid", async ({ page }) => {
+        await restoreChart(page, {
+            plugin: "X/Y Scatter",
+            columns: ["Quantity", "Profit"],
+        });
+        await page.mouse.move(PLOT_CX, PLOT_CY);
+        await page.waitForTimeout(SETTLE_MS);
+        await page.mouse.click(PLOT_CX, PLOT_CY);
+        await page.waitForTimeout(SETTLE_MS);
+        await expectViewerScreenshot(page);
+    });
+
+    test("tooltip fields round-trip plugin_config and defaults strip", async ({
+        page,
+    }) => {
+        await restoreChart(page, {
+            plugin: "X/Y Scatter",
+            columns: ["Quantity", "Profit"],
+            plugin_config: {
+                tooltip_max_column_px: 80,
+                tooltip_opacity: 0.7,
+            },
+        } as never);
+
+        let cfg = await savedPluginConfig(page);
+        expect(cfg.tooltip_max_column_px).toBe(80);
+        expect(cfg.tooltip_opacity).toBe(0.7);
+
+        const defaults = await page.evaluate(async () => {
+            const viewer = document.querySelector("perspective-viewer") as any;
+            const plugin = await viewer.getPlugin();
+            const flat: any[] = [];
+            const walk = (fields: any[]) =>
+                fields.forEach((f) =>
+                    f.kind === "Group" ? walk(f.fields) : flat.push(f),
+                );
+            walk(plugin.plugin_config_schema().fields);
+            return {
+                tooltip_max_column_px: flat.find(
+                    (f) => f.key === "tooltip_max_column_px",
+                )?.default,
+                tooltip_opacity: flat.find((f) => f.key === "tooltip_opacity")
+                    ?.default,
+            };
+        });
+        expect(typeof defaults.tooltip_max_column_px).toBe("number");
+        expect(typeof defaults.tooltip_opacity).toBe("number");
+
+        await restoreChart(page, { plugin_config: defaults } as never);
+        cfg = await savedPluginConfig(page);
+        expect(cfg.tooltip_max_column_px).toBeUndefined();
+        expect(cfg.tooltip_opacity).toBeUndefined();
+    });
+});

--- a/packages/viewer-charts/test/ts/snapshot/tooltip-grid.spec.ts
+++ b/packages/viewer-charts/test/ts/snapshot/tooltip-grid.spec.ts
@@ -22,10 +22,11 @@ async function hoverAndSnapshot(
     page: import("@playwright/test").Page,
     x = PLOT_CX,
     y = PLOT_CY,
+    opts?: { maxDiffPixelRatio?: number },
 ): Promise<void> {
     await page.mouse.move(x, y);
     await page.waitForTimeout(SETTLE_MS);
-    await expectViewerScreenshot(page);
+    await expectViewerScreenshot(page, opts);
 }
 
 test.describe("Tooltip grid", () => {
@@ -70,7 +71,9 @@ test.describe("Tooltip grid", () => {
             columns: ["Sales"],
             group_by: ["Category", "Sub-Category"],
         });
-        await hoverAndSnapshot(page);
+        await hoverAndSnapshot(page, undefined, undefined, {
+            maxDiffPixelRatio: 0.02,
+        });
     });
 
     test("tooltip_max_column_px truncates wide cells", async ({ page }) => {

--- a/packages/viewer-datagrid/src/ts/plugin/column_config_schema.ts
+++ b/packages/viewer-datagrid/src/ts/plugin/column_config_schema.ts
@@ -70,7 +70,8 @@ export default function column_config_schema(
         const pos_bg = this.model!._pos_bg_color[0];
         const neg_bg = this.model!._neg_bg_color[0];
 
-        fields.push({
+        const fg_fields: ControlSpec[] = [];
+        fg_fields.push({
             kind: "Enum",
             key: "number_fg_mode" satisfies keyof ColumnConfig,
             default: "color",
@@ -84,7 +85,7 @@ export default function column_config_schema(
 
         const fg_mode = (current_value?.number_fg_mode as string) ?? "color";
         if (fg_mode !== "disabled") {
-            fields.push({
+            fg_fields.push({
                 kind: "GradientStops",
                 key: "fg_colors" satisfies keyof ColumnConfig,
                 default: stopsToCss([
@@ -96,7 +97,7 @@ export default function column_config_schema(
         }
 
         if (fg_mode === "bar" || fg_mode === "label-bar") {
-            fields.push({
+            fg_fields.push({
                 kind: "Number",
                 key: "fg_gradient" satisfies keyof ColumnConfig,
                 default: column_stats?.abs_max ?? 0,
@@ -104,7 +105,10 @@ export default function column_config_schema(
             });
         }
 
-        fields.push({
+        fields.push({ kind: "Group", key: "fg", fields: fg_fields });
+
+        const bg_fields: ControlSpec[] = [];
+        bg_fields.push({
             kind: "Enum",
             key: "number_bg_mode" satisfies keyof ColumnConfig,
             default: "disabled",
@@ -119,7 +123,7 @@ export default function column_config_schema(
         const bg_mode = (current_value?.number_bg_mode as string) ?? "disabled";
         if (bg_mode !== "disabled") {
             if (bg_mode === "color") {
-                fields.push({
+                bg_fields.push({
                     kind: "GradientStops",
                     key: "bg_colors" satisfies keyof ColumnConfig,
                     default: stopsToCss([
@@ -129,7 +133,7 @@ export default function column_config_schema(
                     discrete: true,
                 });
             } else {
-                fields.push({
+                bg_fields.push({
                     kind: "GradientStops",
                     key: "bg_colors" satisfies keyof ColumnConfig,
                     default: stopsToCss([
@@ -151,13 +155,15 @@ export default function column_config_schema(
         }
 
         if (bg_mode === "gradient") {
-            fields.push({
+            bg_fields.push({
                 kind: "Number",
                 key: "bg_gradient" satisfies keyof ColumnConfig,
                 include: true,
                 default: column_stats?.abs_max ?? 0,
             });
         }
+
+        fields.push({ kind: "Group", key: "bg", fields: bg_fields });
 
         fields.push({ kind: "NumberFormat" });
     } else if (type === "date" || type === "datetime") {

--- a/packages/viewer-datagrid/src/ts/plugin/column_config_schema.ts
+++ b/packages/viewer-datagrid/src/ts/plugin/column_config_schema.ts
@@ -29,16 +29,6 @@ export interface ColumnConfigSchema {
 /**
  * Plugin schema for the Datagrid column-settings sidebar. Returns the
  * controls the viewer should render in the Style tab for a given column.
- *
- * Each entry in `fields` is a `ControlSpec` discriminated by `kind`.
- * Composite kinds (`NumberStyle`, `DatetimeFormat`, `StringFormat`,
- * `NumberFormat`, `AggregateDepth`) own a fixed key namespace and
- * carry only their `default`. Primitive kinds (`Enum`, `Bool`, `Color`,
- * etc.) carry their own `key` (storage) and `label` (UI) inline.
- *
- * Aggregate Depth is plugin-owned — surfaced only inside the Datagrid
- * because rollup-mode pivots are a Datagrid concern. Emitted only when
- * the active view has a non-empty `group_by` and rollup mode is `Rollup`.
  */
 interface ColumnStats {
     abs_max?: number;
@@ -54,7 +44,6 @@ export default function column_config_schema(
     column_stats?: ColumnStats,
 ): ColumnConfigSchema {
     const fields: ControlSpec[] = [];
-
     if ((viewer_config?.split_by?.length ?? 0) === 0) {
         fields.push({
             kind: "Number",
@@ -64,12 +53,19 @@ export default function column_config_schema(
         });
     }
 
+    const group_by = viewer_config?.group_by ?? [];
+    const is_rollup =
+        (viewer_config?.group_rollup_mode ?? "rollup") === "rollup";
+
+    if (group_by.length > 0 && is_rollup) {
+        fields.push({ kind: "AggregateDepth" });
+    }
+
     if (type === "integer" || type === "float") {
         const pos_fg = this.model!._pos_fg_color[0];
         const neg_fg = this.model!._neg_fg_color[0];
         const pos_bg = this.model!._pos_bg_color[0];
         const neg_bg = this.model!._neg_bg_color[0];
-
         const fg_fields: ControlSpec[] = [];
         fg_fields.push({
             kind: "Enum",
@@ -104,8 +100,6 @@ export default function column_config_schema(
                 include: true,
             });
         }
-
-        fields.push({ kind: "Group", key: "fg", fields: fg_fields });
 
         const bg_fields: ControlSpec[] = [];
         bg_fields.push({
@@ -163,12 +157,14 @@ export default function column_config_schema(
             });
         }
 
-        fields.push({ kind: "Group", key: "bg", fields: bg_fields });
+        fields.push({
+            kind: "Group",
+            key: "color",
+            fields: [...fg_fields, ...bg_fields],
+        });
 
         fields.push({ kind: "NumberFormat" });
     } else if (type === "date" || type === "datetime") {
-        fields.push({ kind: "DatetimeFormat" });
-
         fields.push({
             kind: "Enum",
             key: "datetime_color_mode" satisfies keyof ColumnConfig,
@@ -190,9 +186,9 @@ export default function column_config_schema(
                 default: this.model!._color[0],
             });
         }
-    } else if (type === "string") {
-        fields.push({ kind: "StringFormat" });
 
+        fields.push({ kind: "DatetimeFormat" });
+    } else if (type === "string") {
         fields.push({
             kind: "Enum",
             key: "string_color_mode" satisfies keyof ColumnConfig,
@@ -219,14 +215,8 @@ export default function column_config_schema(
                 default: this.model!._color[0],
             });
         }
-    }
 
-    const group_by = viewer_config?.group_by ?? [];
-    const is_rollup =
-        (viewer_config?.group_rollup_mode ?? "rollup") === "rollup";
-
-    if (group_by.length > 0 && is_rollup) {
-        fields.push({ kind: "AggregateDepth" });
+        fields.push({ kind: "StringFormat" });
     }
 
     return { fields };

--- a/packages/viewer-datagrid/test/js/control_groups.spec.ts
+++ b/packages/viewer-datagrid/test/js/control_groups.spec.ts
@@ -32,7 +32,7 @@ test.describe("Datagrid column style control groups", function () {
         await view.columnSettingsSidebar.container.waitFor();
     }
 
-    test("numeric column nests fg/bg triples in default-open groups", async function ({
+    test("numeric column nests its color controls in a default-open group", async function ({
         page,
     }) {
         const view = new PspViewer(page);
@@ -41,23 +41,22 @@ test.describe("Datagrid column style control groups", function () {
         const sidebar = view.columnSettingsSidebar.container;
         const groups = sidebar.locator("details.control-group");
 
-        await expect(groups).toHaveCount(3);
+        await expect(groups).toHaveCount(2);
         await expect(
             groups.last().locator("summary #format-group-label"),
         ).toHaveCount(1);
 
-        const fg = groups.first();
-        const bg = groups.nth(1);
-        await expect(fg).toHaveJSProperty("open", true);
-        await expect(bg).toHaveJSProperty("open", true);
-        await expect(fg.locator("summary #fg-group-label")).toHaveCount(1);
-        await expect(bg.locator("summary #bg-group-label")).toHaveCount(1);
+        const color = groups.first();
+        await expect(color).toHaveJSProperty("open", true);
+        await expect(color.locator("summary #color-group-label")).toHaveCount(
+            1,
+        );
 
-        await expect(fg.locator("#number_fg_mode-label")).toHaveCount(1);
-        await expect(fg.locator("#fg_colors-label")).toHaveCount(1);
-        await expect(fg.locator("#fg_gradient-label")).toHaveCount(0);
-        await expect(bg.locator("#number_bg_mode-label")).toHaveCount(1);
-        await expect(bg.locator("#bg_colors-label")).toHaveCount(0);
+        await expect(color.locator("#number_fg_mode-label")).toHaveCount(1);
+        await expect(color.locator("#fg_colors-label")).toHaveCount(1);
+        await expect(color.locator("#fg_gradient-label")).toHaveCount(0);
+        await expect(color.locator("#number_bg_mode-label")).toHaveCount(1);
+        await expect(color.locator("#bg_colors-label")).toHaveCount(0);
 
         await expect(
             sidebar.locator(
@@ -73,23 +72,35 @@ test.describe("Datagrid column style control groups", function () {
         await openNumericStyleTab(page, view);
 
         const sidebar = view.columnSettingsSidebar.container;
-        const fg = sidebar.locator("details.control-group").first();
-        await fg
+        const color = sidebar.locator("details.control-group").first();
+        await color
             .locator("div.row", {
                 has: page.locator("label#number_fg_mode-label"),
             })
             .locator("select")
             .selectOption("label-bar");
 
-        await expect(fg.locator("#fg_gradient-label")).toHaveCount(1);
-        await expect(fg).toHaveJSProperty("open", true);
+        await expect(color.locator("#fg_gradient-label")).toHaveCount(1);
+        await expect(color).toHaveJSProperty("open", true);
 
         const token = (await view.save()) as any;
         const config = token.columns_config["Row ID"];
 
         expect(config.number_fg_mode).toEqual("label-bar");
-        expect(config.fg_gradient).not.toBeUndefined();
-        expect(config.fg).toBeUndefined();
-        expect(token.plugin_config.fg).toBeUndefined();
+        expect(config.fg_gradient).toBeUndefined();
+        expect(config.color).toBeUndefined();
+        expect(token.plugin_config.color).toBeUndefined();
+
+        const received = await page.evaluate(() => {
+            const rt = (
+                document.querySelector("perspective-viewer-datagrid") as any
+            ).shadowRoot.querySelector("regular-table");
+            const sym = Object.getOwnPropertySymbols(rt).find((s) =>
+                String(s).includes("Perspective Column Config"),
+            );
+            return sym ? rt[sym] : undefined;
+        });
+
+        expect(received?.["Row ID"]?.fg_gradient).not.toBeUndefined();
     });
 });

--- a/packages/viewer-datagrid/test/js/control_groups.spec.ts
+++ b/packages/viewer-datagrid/test/js/control_groups.spec.ts
@@ -1,0 +1,95 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { PageView as PspViewer, expect, test } from "@perspective-dev/test";
+
+test.describe("Datagrid column style control groups", function () {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/tools/test/src/html/basic-test.html");
+        await page.evaluate(async () => {
+            while (!(window as any)["__TEST_PERSPECTIVE_READY__"]) {
+                await new Promise((x) => setTimeout(x, 10));
+            }
+        });
+    });
+
+    async function openNumericStyleTab(page: any, view: PspViewer) {
+        await view.openSettingsPanel();
+        const editBtn = view.dataGrid.regularTable.editBtnRow
+            .locator("th.psp-menu-enabled span")
+            .first();
+
+        await editBtn.click();
+        await view.columnSettingsSidebar.container.waitFor();
+    }
+
+    test("numeric column nests fg/bg triples in default-open groups", async function ({
+        page,
+    }) {
+        const view = new PspViewer(page);
+        await openNumericStyleTab(page, view);
+
+        const sidebar = view.columnSettingsSidebar.container;
+        const groups = sidebar.locator("details.control-group");
+
+        await expect(groups).toHaveCount(3);
+        await expect(
+            groups.last().locator("summary #format-group-label"),
+        ).toHaveCount(1);
+
+        const fg = groups.first();
+        const bg = groups.nth(1);
+        await expect(fg).toHaveJSProperty("open", true);
+        await expect(bg).toHaveJSProperty("open", true);
+        await expect(fg.locator("summary #fg-group-label")).toHaveCount(1);
+        await expect(bg.locator("summary #bg-group-label")).toHaveCount(1);
+
+        await expect(fg.locator("#number_fg_mode-label")).toHaveCount(1);
+        await expect(fg.locator("#fg_colors-label")).toHaveCount(1);
+        await expect(fg.locator("#fg_gradient-label")).toHaveCount(0);
+        await expect(bg.locator("#number_bg_mode-label")).toHaveCount(1);
+        await expect(bg.locator("#bg_colors-label")).toHaveCount(0);
+
+        await expect(
+            sidebar.locator(
+                "details.control-group #column_size_override-label",
+            ),
+        ).toHaveCount(0);
+    });
+
+    test("dynamic gating works inside a group and serializes flat", async function ({
+        page,
+    }) {
+        const view = new PspViewer(page);
+        await openNumericStyleTab(page, view);
+
+        const sidebar = view.columnSettingsSidebar.container;
+        const fg = sidebar.locator("details.control-group").first();
+        await fg
+            .locator("div.row", {
+                has: page.locator("label#number_fg_mode-label"),
+            })
+            .locator("select")
+            .selectOption("label-bar");
+
+        await expect(fg.locator("#fg_gradient-label")).toHaveCount(1);
+        await expect(fg).toHaveJSProperty("open", true);
+
+        const token = (await view.save()) as any;
+        const config = token.columns_config["Row ID"];
+
+        expect(config.number_fg_mode).toEqual("label-bar");
+        expect(config.fg_gradient).not.toBeUndefined();
+        expect(config.fg).toBeUndefined();
+        expect(token.plugin_config.fg).toBeUndefined();
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,6 +271,27 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  examples/cdn:
+    dependencies:
+      '@perspective-dev/client':
+        specifier: 'workspace:'
+        version: link:../../rust/perspective-js
+      '@perspective-dev/server':
+        specifier: 'workspace:'
+        version: link:../../rust/perspective-server
+      '@perspective-dev/viewer':
+        specifier: 'workspace:'
+        version: link:../../rust/perspective-viewer
+      '@perspective-dev/viewer-charts':
+        specifier: 'workspace:'
+        version: link:../../packages/viewer-charts
+      '@perspective-dev/viewer-datagrid':
+        specifier: 'workspace:'
+        version: link:../../packages/viewer-datagrid
+      superstore-arrow:
+        specifier: 'catalog:'
+        version: 3.2.0
+
   examples/esbuild-clickhouse-virtual:
     dependencies:
       '@clickhouse/client-web':

--- a/rust/perspective-js/test/js/constructors/arrow.spec.ts
+++ b/rust/perspective-js/test/js/constructors/arrow.spec.ts
@@ -176,6 +176,70 @@ test.describe("Arrow", function () {
             await view.delete();
             await table.delete();
         });
+
+        // https://github.com/perspective-dev/perspective/issues/1346
+        test("Unsigned and 64-bit integer columns are not sign-flipped by JSON output", async function () {
+            const tableData = arrow.tableFromArrays({
+                u8: arrow.vectorFromArray([0, 127, 128, 255], new arrow.Uint8()),
+                u16: arrow.vectorFromArray(
+                    [0, 32767, 32768, 65535],
+                    new arrow.Uint16(),
+                ),
+                u32: arrow.vectorFromArray(
+                    [0, 2147483647, 2147483648, 4166343120],
+                    new arrow.Uint32(),
+                ),
+                u64: arrow.vectorFromArray(
+                    [0n, 4166343120n, 9007199254740991n, 9223372036854775808n],
+                    new arrow.Uint64(),
+                ),
+                i64: arrow.vectorFromArray(
+                    [-9007199254740991n, -2147483649n, 4166343120n, 9007199254740991n],
+                    new arrow.Int64(),
+                ),
+            });
+
+            const table = await perspective.table(arrow.tableToIPC(tableData));
+            const view = await table.view();
+            expect(await view.to_columns()).toEqual({
+                u8: [0, 127, 128, 255],
+                u16: [0, 32767, 32768, 65535],
+                u32: [0, 2147483647, 2147483648, 4166343120],
+                u64: [0, 4166343120, 9007199254740991, 9223372036854775808],
+                i64: [
+                    -9007199254740991, -2147483649, 4166343120,
+                    9007199254740991,
+                ],
+            });
+
+            await view.delete();
+            await table.delete();
+        });
+
+        // https://github.com/perspective-dev/perspective/issues/1346
+        test("Unsigned group-by keys are not sign-flipped in __ROW_PATH__", async function () {
+            const tableData = arrow.tableFromArrays({
+                u32: arrow.vectorFromArray(
+                    [4166343120, 4166343120, 5],
+                    new arrow.Uint32(),
+                ),
+            });
+
+            const table = await perspective.table(arrow.tableToIPC(tableData));
+            const view = await table.view({
+                group_by: ["u32"],
+                columns: ["u32"],
+                aggregates: { u32: "count" },
+            });
+
+            expect(await view.to_columns()).toEqual({
+                __ROW_PATH__: [[], [5], [4166343120]],
+                u32: [3, 1, 2],
+            });
+
+            await view.delete();
+            await table.delete();
+        });
     });
 
     test.describe("Malformed input", function () {

--- a/rust/perspective-js/test/js/constructors/arrow.spec.ts
+++ b/rust/perspective-js/test/js/constructors/arrow.spec.ts
@@ -177,10 +177,12 @@ test.describe("Arrow", function () {
             await table.delete();
         });
 
-        // https://github.com/perspective-dev/perspective/issues/1346
         test("Unsigned and 64-bit integer columns are not sign-flipped by JSON output", async function () {
             const tableData = arrow.tableFromArrays({
-                u8: arrow.vectorFromArray([0, 127, 128, 255], new arrow.Uint8()),
+                u8: arrow.vectorFromArray(
+                    [0, 127, 128, 255],
+                    new arrow.Uint8(),
+                ),
                 u16: arrow.vectorFromArray(
                     [0, 32767, 32768, 65535],
                     new arrow.Uint16(),
@@ -194,7 +196,12 @@ test.describe("Arrow", function () {
                     new arrow.Uint64(),
                 ),
                 i64: arrow.vectorFromArray(
-                    [-9007199254740991n, -2147483649n, 4166343120n, 9007199254740991n],
+                    [
+                        -9007199254740991n,
+                        -2147483649n,
+                        4166343120n,
+                        9007199254740991n,
+                    ],
                     new arrow.Int64(),
                 ),
             });
@@ -216,7 +223,6 @@ test.describe("Arrow", function () {
             await table.delete();
         });
 
-        // https://github.com/perspective-dev/perspective/issues/1346
         test("Unsigned group-by keys are not sign-flipped in __ROW_PATH__", async function () {
             const tableData = arrow.tableFromArrays({
                 u32: arrow.vectorFromArray(

--- a/rust/perspective-server/cmake/Boost.txt.in
+++ b/rust/perspective-server/cmake/Boost.txt.in
@@ -5,9 +5,16 @@ project(Boost-download NONE)
 # Makes GIT_SUBMODULES "" in ExternalProject_Add skip initializing submodules
 cmake_policy(SET CMP0097 NEW)
 
+if(NOT CMAKE_VERSION VERSION_LESS "3.19")
+  set(PSP_BOOST_DOWNLOAD_ARGS INACTIVITY_TIMEOUT 30)
+endif()
+
 include(ExternalProject)
 ExternalProject_Add(Boost
-  URL               "https://sourceforge.net/projects/boost/files/boost/1.82.0/boost_1_82_0.tar.gz"
+  URL               "https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.gz"
+                    "https://sourceforge.net/projects/boost/files/boost/1.82.0/boost_1_82_0.tar.gz"
+  URL_HASH          SHA256=66a469b6e608a51f8347236f4912e27dc5c60c60d7d53ae9bfe4683316c6f04c
+  ${D}{PSP_BOOST_DOWNLOAD_ARGS}
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/Boost-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/Boost-build"
   SOURCE_SUBDIR     ""

--- a/rust/perspective-server/cpp/perspective/src/cpp/view.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/view.cpp
@@ -1792,21 +1792,32 @@ write_scalar(
         case DTYPE_BOOL:
             writer.Bool(scalar.get<bool>());
             break;
-        case DTYPE_UINT8:
         case DTYPE_INT8:
-            writer.Int(scalar.get<int8_t>());
+            writer.Int(scalar.get<std::int8_t>());
+            break;
+        case DTYPE_INT16:
+            writer.Int(scalar.get<std::int16_t>());
+            break;
+        case DTYPE_INT32:
+            writer.Int(scalar.get<std::int32_t>());
+            break;
+        case DTYPE_INT64:
+            writer.Int64(scalar.get<std::int64_t>());
+            break;
+        // Unsigned dtypes must read the matching union member — get<T> is a
+        // raw union read, so the signed accessor sign-flips values with the
+        // top bit set (#1346).
+        case DTYPE_UINT8:
+            writer.Uint(scalar.get<std::uint8_t>());
             break;
         case DTYPE_UINT16:
-        case DTYPE_INT16:
-            writer.Int(scalar.get<int16_t>());
+            writer.Uint(scalar.get<std::uint16_t>());
             break;
         case DTYPE_UINT32:
-        case DTYPE_INT32:
-            writer.Int(scalar.get<int32_t>());
+            writer.Uint(scalar.get<std::uint32_t>());
             break;
         case DTYPE_UINT64:
-        case DTYPE_INT64:
-            writer.Int64(scalar.get<int64_t>());
+            writer.Uint64(scalar.get<std::uint64_t>());
             break;
         case DTYPE_FLOAT32:
             if (scalar.is_nan()) {

--- a/rust/perspective-server/cpp/perspective/src/cpp/view.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/view.cpp
@@ -1804,9 +1804,6 @@ write_scalar(
         case DTYPE_INT64:
             writer.Int64(scalar.get<std::int64_t>());
             break;
-        // Unsigned dtypes must read the matching union member — get<T> is a
-        // raw union read, so the signed accessor sign-flips values with the
-        // top bit set (#1346).
         case DTYPE_UINT8:
             writer.Uint(scalar.get<std::uint8_t>());
             break;

--- a/rust/perspective-viewer/build.mjs
+++ b/rust/perspective-viewer/build.mjs
@@ -176,6 +176,11 @@ export async function build_all() {
         "gruvbox",
         "gruvbox-dark",
         "dracula",
+        "nord",
+        "ledger",
+        "blueprint",
+        "eggplant",
+        "velvet",
         "themes",
     ];
 

--- a/rust/perspective-viewer/src/css/column-settings-panel.css
+++ b/rust/perspective-viewer/src/css/column-settings-panel.css
@@ -217,6 +217,10 @@
         content: var(--psp-label--notation--content, "Notation");
     }
 
+    label#compact-display-label:before {
+        content: var(--psp-label--compact-display--content, "Compact Display");
+    }
+
     label#use-grouping-label:before {
         content: var(--psp-label--use-grouping--content, "Use Grouping");
     }

--- a/rust/perspective-viewer/src/css/column-settings-panel.css
+++ b/rust/perspective-viewer/src/css/column-settings-panel.css
@@ -237,6 +237,18 @@
         content: var(--psp-label--bg-gradient--content, "Max Value");
     }
 
+    label#fg-group-label:before {
+        content: var(--psp-label--group-fg--content, "Foreground");
+    }
+
+    label#bg-group-label:before {
+        content: var(--psp-label--group-bg--content, "Background");
+    }
+
+    label#format-group-label:before {
+        content: var(--psp-label--group-format--content, "Format");
+    }
+
     label#rounding-priority-label:before {
         content: var(
             --psp-label--rounding-priority--content,

--- a/rust/perspective-viewer/src/css/column-settings-panel.css
+++ b/rust/perspective-viewer/src/css/column-settings-panel.css
@@ -237,16 +237,19 @@
         content: var(--psp-label--bg-gradient--content, "Max Value");
     }
 
-    label#fg-group-label:before {
-        content: var(--psp-label--group-fg--content, "Foreground");
-    }
-
-    label#bg-group-label:before {
-        content: var(--psp-label--group-bg--content, "Background");
+    label#color-group-label:before {
+        content: var(--psp-label--group-color--content, "Color");
     }
 
     label#format-group-label:before {
         content: var(--psp-label--group-format--content, "Format");
+    }
+
+    label#column_size_override-label:before {
+        content: var(
+            --psp-label--column-size-override--content,
+            "Column Width"
+        );
     }
 
     label#rounding-priority-label:before {

--- a/rust/perspective-viewer/src/css/column-style.css
+++ b/rust/perspective-viewer/src/css/column-style.css
@@ -17,6 +17,8 @@
     #window-editor-container {
         outline: none;
         user-select: none;
+        margin-right: -6px;
+        padding-right: 6px;
 
         .bool-field-desc {
             font-size: 10px;
@@ -214,6 +216,86 @@
         fieldset.style-control {
             border: none;
             padding: 0px 0;
+        }
+
+        details.control-group {
+            margin: 0 -8px 0 -8px;
+            padding: 0 8px 0 8px;
+
+            &:not([open]):hover {
+                color: var(--psp--background-color);
+                background-color: var(--psp--color);
+                border-color: var(--psp--color) !important;
+            }
+
+            &[open] summary:hover {
+                color: var(--psp--color);
+            }
+
+            &:not(:first-child) {
+                border-top: 1px solid var(--psp-inactive--color);
+            }
+
+            &:last-of-type {
+                border-bottom: 1px solid var(--psp-inactive--color);
+            }
+
+            &:first-child {
+                margin-top: -12px;
+            }
+
+            > summary {
+                display: flex;
+                align-items: center;
+                cursor: pointer;
+                list-style: none;
+                margin: 0;
+                padding-right: 6px;
+                outline: none;
+
+                &::-webkit-details-marker {
+                    display: none;
+                }
+
+                > span.control-group-chevron {
+                    flex: 0 0 8px;
+                    height: 4px;
+                    background-color: currentColor;
+                    mask-image: var(--psp-icon--select-arrow--mask-image);
+                    -webkit-mask-image: var(
+                        --psp-icon--select-arrow--mask-image
+                    );
+                    -webkit-mask-repeat: no-repeat;
+                    mask-repeat: no-repeat;
+                    mask-size: cover;
+                    -webkit-mask-position: center;
+                    mask-position: center;
+                    transform: rotate(-90deg);
+                    margin-right: 2px;
+                }
+
+                label {
+                    padding-top: 8px;
+                    padding-bottom: 8px;
+                    pointer-events: none;
+                    flex: 1 1 auto;
+                    width: auto;
+                    margin: 0 0 0 6px;
+                }
+            }
+
+            &[open] > summary label {
+                padding-bottom: 8px;
+            }
+
+            &[open] > summary {
+                color: var(--psp-inactive--color);
+                margin-bottom: 2px;
+            }
+
+            &[open] > summary > span.control-group-chevron {
+                transform: none;
+            }
         }
 
         .color-gradient-container {

--- a/rust/perspective-viewer/src/css/containers/tabs.css
+++ b/rust/perspective-viewer/src/css/containers/tabs.css
@@ -13,13 +13,23 @@
 
 :host {
     #format-tab {
-        overflow: scroll;
+        overflow: auto;
+        scrollbar-gutter: stable;
+    }
+
+    #style-tab {
+        margin-right: -6px;
+        #column-style-container {
+            margin-right: 6px;
+        }
     }
 
     #plugin-tab {
         overflow-x: hidden;
-        overflow-y: scroll;
-        padding: 12px 0 0 0;
+        overflow-y: auto;
+        scrollbar-gutter: stable;
+        padding: 12px 0 0 8px;
+        margin-left: -8px;
     }
 
     .tab-content {

--- a/rust/perspective-viewer/src/css/dom/select.css
+++ b/rust/perspective-viewer/src/css/dom/select.css
@@ -33,6 +33,25 @@
             bottom: 0px;
             cursor: pointer;
         }
+
+        .select-arrow {
+            position: absolute;
+            pointer-events: none;
+            top: 50%;
+            right: 6px;
+            width: 6px;
+            height: 4px;
+            transform: translateY(-50%);
+            background-color: currentColor;
+            -webkit-mask-image: var(--psp-icon--select-arrow--mask-image);
+            mask-image: var(--psp-icon--select-arrow--mask-image);
+            -webkit-mask-repeat: no-repeat;
+            mask-repeat: no-repeat;
+            -webkit-mask-position: center;
+            mask-position: center;
+            -webkit-mask-size: contain;
+            mask-size: contain;
+        }
     }
 
     select {
@@ -46,14 +65,6 @@
         /* font-size: 10px; */
         font-family: inherit;
         background-color: transparent;
-        background-image: var(--psp-icon--select-arrow--mask-image);
-        background-position: right 2px center;
-        background-repeat: no-repeat;
-
-        &.invert:focus-within,
-        &.invert:hover {
-            background-image: var(--psp-icon--select-arrow-hover--mask-image);
-        }
 
         option {
             color: var(--psp--color, inherit);

--- a/rust/perspective-viewer/src/css/plugin-selector.css
+++ b/rust/perspective-viewer/src/css/plugin-selector.css
@@ -43,6 +43,7 @@
 
             .plugin-selector-options {
                 overflow-y: auto;
+                height: 100%;
             }
 
             &.open {

--- a/rust/perspective-viewer/src/css/plugin-settings-panel.css
+++ b/rust/perspective-viewer/src/css/plugin-settings-panel.css
@@ -132,4 +132,40 @@
     label#legend_opacity-label:before {
         content: var(--psp-label--legend-opacity--content);
     }
+
+    label#tooltip_max_column_px-label:before {
+        content: var(--psp-label--tooltip-max-column-px--content);
+    }
+
+    label#tooltip_opacity-label:before {
+        content: var(--psp-label--tooltip-opacity--content);
+    }
+
+    label#axes-group-label:before {
+        content: var(--psp-label--group-axes--content, "Axes");
+    }
+
+    label#facets-group-label:before {
+        content: var(--psp-label--group-facets--content, "Facets");
+    }
+
+    label#glyph-group-label:before {
+        content: var(--psp-label--group-glyph--content, "Glyphs");
+    }
+
+    label#density-group-label:before {
+        content: var(--psp-label--group-density--content, "Density");
+    }
+
+    label#basemap-group-label:before {
+        content: var(--psp-label--group-basemap--content, "Basemap");
+    }
+
+    label#legend-group-label:before {
+        content: var(--psp-label--group-legend--content, "Legend");
+    }
+
+    label#tooltip-group-label:before {
+        content: var(--psp-label--group-tooltip--content, "Tooltips");
+    }
 }

--- a/rust/perspective-viewer/src/css/viewer.css
+++ b/rust/perspective-viewer/src/css/viewer.css
@@ -125,7 +125,6 @@
         0 12.5px 0 -11.5px var(--psp-inactive--border-color);
 }
 
-
 :host .sidebar_close_button {
     position: absolute;
     top: 0;

--- a/rust/perspective-viewer/src/css/viewer.css
+++ b/rust/perspective-viewer/src/css/viewer.css
@@ -125,10 +125,6 @@
         0 12.5px 0 -11.5px var(--psp-inactive--border-color);
 }
 
-:host input[type="number"]::-webkit-inner-spin-button {
-    transform: scale(1.5) translateX(-5px);
-    filter: var(--psp-input--filter);
-}
 
 :host .sidebar_close_button {
     position: absolute;

--- a/rust/perspective-viewer/src/rust/agent/tools.rs
+++ b/rust/perspective-viewer/src/rust/agent/tools.rs
@@ -709,6 +709,9 @@ fn control_schema_entries(spec: &ControlSpec) -> Vec<(String, Value)> {
             "aggregate_depth".to_owned(),
             json!({ "type": "integer", "description": "Group-by rollup depth override" }),
         )],
+        ControlSpec::Group { fields, .. } => {
+            fields.iter().flat_map(control_schema_entries).collect()
+        },
     }
 }
 

--- a/rust/perspective-viewer/src/rust/agent/tools.rs
+++ b/rust/perspective-viewer/src/rust/agent/tools.rs
@@ -679,7 +679,7 @@ fn control_schema_entries(spec: &ControlSpec) -> Vec<(String, Value)> {
                 }),
             )]
         },
-        ControlSpec::DatetimeFormat => vec![(
+        ControlSpec::DatetimeFormat { .. } => vec![(
             "date_format".to_owned(),
             json!({ "description": "Datetime display format: a style preset or custom format fields" }),
         )],
@@ -701,7 +701,7 @@ fn control_schema_entries(spec: &ControlSpec) -> Vec<(String, Value)> {
             "symbols".to_owned(),
             json!({ "type": "object", "description": "Map of column values to symbol names" }),
         )],
-        ControlSpec::NumberFormat => vec![(
+        ControlSpec::NumberFormat { .. } => vec![(
             "number_format".to_owned(),
             json!({ "type": "object", "description": "Intl.NumberFormat-style options" }),
         )],

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab.rs
@@ -33,7 +33,8 @@ use crate::components::string_column_style::StringColumnStyle;
 use crate::components::style_controls::CustomNumberFormat;
 use crate::config::{
     ColumnConfigFieldUpdate, ControlSpec, CssKind, CustomNumberFormatConfig,
-    DatetimeColumnStyleConfig, NamedValue, NumberSeriesStyleConfig, StringColumnStyleConfig,
+    DatetimeColumnStyleConfig, NamedValue, NumberFormatDefaults, NumberSeriesStyleConfig,
+    StringColumnStyleConfig,
 };
 use crate::presentation::Presentation;
 use crate::queries::{fetch_column_abs_max, get_column_config_schema, named_values};
@@ -256,13 +257,15 @@ fn render_leaf(spec: ControlSpec, keys: &[String], ctx: &FieldRenderCtx) -> Opti
                 />
             }
         },
-        ControlSpec::DatetimeFormat => {
+        ControlSpec::DatetimeFormat { default } => {
             let config: Option<DatetimeColumnStyleConfig> = deser_sub(raw_config);
             let enable_time_config = props.ty.unwrap() == ColumnType::Datetime;
+            let default_format = Rc::new(default.unwrap_or_default());
             html! {
                 <DatetimeColumnStyle
                     {enable_time_config}
                     {config}
+                    {default_format}
                     on_change={on_change.clone()}
                     keys={keys.to_vec()}
                 />
@@ -295,18 +298,25 @@ fn render_leaf(spec: ControlSpec, keys: &[String], ctx: &FieldRenderCtx) -> Opti
                 />
             }
         },
-        ControlSpec::NumberFormat => {
+        ControlSpec::NumberFormat { default } => {
             let restored_config: CustomNumberFormatConfig = raw_config
                 .as_ref()
                 .and_then(|m| m.get("number_format"))
                 .and_then(|v| serde_json::from_value(v.clone()).ok())
                 .unwrap_or_default();
 
+            let view_type = props.ty.unwrap();
+            let defaults = Rc::new(NumberFormatDefaults::resolve(
+                default.as_ref(),
+                view_type == ColumnType::Float,
+            ));
+
             html! {
                 <CustomNumberFormat
                     {restored_config}
+                    {defaults}
                     on_change={on_change.clone()}
-                    view_type={props.ty.unwrap()}
+                    {view_type}
                     column_name={props.column_name.clone()}
                     keys={keys.to_vec()}
                 />

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab.rs
@@ -193,10 +193,7 @@ fn render_specs(specs: Vec<ControlSpec>, ctx: &FieldRenderCtx) -> Vec<Html> {
             ControlSpec::Group { key, fields } => {
                 let children = render_specs(fields, ctx);
                 (!children.is_empty()).then(|| {
-                    let open = !ctx
-                        .props
-                        .presentation
-                        .is_control_group_collapsed(&key);
+                    let open = !ctx.props.presentation.is_control_group_collapsed(&key);
 
                     html! {
                         <ControlGroup

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab.rs
@@ -14,25 +14,26 @@ mod agg_depth_selector;
 pub(crate) mod primitive_field;
 mod symbol;
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 
 use itertools::Itertools;
 use perspective_client::config::ColumnType;
-use yew::{Html, Properties, function_component, html};
+use yew::{Callback, Html, Properties, function_component, html};
 
 use self::agg_depth_selector::*;
 use self::primitive_field::{
     BoolField, ColorField, EnumField, GradientStopsField, NumberFieldPrimitive, PaletteField,
 };
 use crate::components::column_settings_sidebar::style_tab::symbol::SymbolStyle;
+use crate::components::containers::control_group::ControlGroup;
 use crate::components::datetime_column_style::DatetimeColumnStyle;
 use crate::components::number_series_style::NumberSeriesStyle;
 use crate::components::string_column_style::StringColumnStyle;
 use crate::components::style_controls::CustomNumberFormat;
 use crate::config::{
-    ControlSpec, CssKind, CustomNumberFormatConfig, DatetimeColumnStyleConfig,
-    NumberSeriesStyleConfig, StringColumnStyleConfig,
+    ColumnConfigFieldUpdate, ControlSpec, CssKind, CustomNumberFormatConfig,
+    DatetimeColumnStyleConfig, NamedValue, NumberSeriesStyleConfig, StringColumnStyleConfig,
 };
 use crate::presentation::Presentation;
 use crate::queries::{fetch_column_abs_max, get_column_config_schema, named_values};
@@ -133,241 +134,27 @@ pub fn StyleTab(props: &StyleTabProps) -> Html {
         })
     };
 
-    fn deser_sub<T: serde::de::DeserializeOwned>(
-        raw: &Option<serde_json::Map<String, serde_json::Value>>,
-    ) -> Option<T> {
-        raw.as_ref()
-            .and_then(|m| serde_json::from_value::<T>(serde_json::Value::Object(m.clone())).ok())
-    }
+    let on_group_toggle = {
+        let presentation = props.presentation.clone();
+        yew::Callback::from(move |(key, open): (String, bool)| {
+            presentation.set_control_group_collapsed(&key, !open);
+        })
+    };
+
+    let ctx = FieldRenderCtx {
+        props,
+        raw_config: &raw_config,
+        on_change: &on_change,
+        on_group_toggle: &on_group_toggle,
+        on_pin: &on_pin,
+        named_colors: &named_colors,
+        named_palettes: &named_palettes,
+        named_gradients: &named_gradients,
+        restored: &restored,
+    };
 
     let components = schema
-        .map(|schema| {
-            schema
-                .fields
-                .into_iter()
-                .filter_map(|spec| {
-                    let keys: Vec<String> = spec
-                        .serialized_keys()
-                        .into_iter()
-                        .map(|s| s.to_string())
-                        .collect();
-                    let component = match spec {
-                        ControlSpec::AggregateDepth => {
-                            let aggregate_depth = raw_config
-                                .as_ref()
-                                .and_then(|m| m.get("aggregate_depth"))
-                                .and_then(|v| v.as_u64())
-                                .unwrap_or(0)
-                                as u32;
-                            html! {
-                                <AggregateDepthSelector
-                                    group_by_depth={props.group_by_depth}
-                                    on_change={on_change.clone()}
-                                    column_name={props.column_name.to_owned()}
-                                    value={aggregate_depth}
-                                    keys={keys.clone()}
-                                />
-                            }
-                        },
-                        ControlSpec::NumberSeriesStyle {
-                            default: default_config,
-                        } => {
-                            let config: Option<NumberSeriesStyleConfig> = deser_sub(&raw_config);
-                            html! {
-                                <NumberSeriesStyle
-                                    {config}
-                                    {default_config}
-                                    on_change={on_change.clone()}
-                                    keys={keys.clone()}
-                                />
-                            }
-                        },
-                        ControlSpec::DatetimeFormat => {
-                            let config: Option<DatetimeColumnStyleConfig> = deser_sub(&raw_config);
-                            let enable_time_config = props.ty.unwrap() == ColumnType::Datetime;
-                            html! {
-                                <DatetimeColumnStyle
-                                    {enable_time_config}
-                                    {config}
-                                    on_change={on_change.clone()}
-                                    keys={keys.clone()}
-                                />
-                            }
-                        },
-                        ControlSpec::StringFormat => {
-                            let config: Option<StringColumnStyleConfig> = deser_sub(&raw_config);
-                            html! {
-                                <StringColumnStyle
-                                    {config}
-                                    on_change={on_change.clone()}
-                                    keys={keys.clone()}
-                                />
-                            }
-                        },
-                        ControlSpec::Symbols {
-                            default: default_config,
-                        } => {
-                            let restored_config: HashMap<String, String> = raw_config
-                                .as_ref()
-                                .and_then(|m| m.get("symbols"))
-                                .and_then(|v| serde_json::from_value(v.clone()).ok())
-                                .unwrap_or_default();
-
-                            html! {
-                                <SymbolStyle
-                                    {default_config}
-                                    restored_config={Some(restored_config)}
-                                    on_change={on_change.clone()}
-                                    column_name={props.column_name.clone()}
-                                    selected_theme={props.selected_theme.clone()}
-                                    session={props.session.clone()}
-                                    keys={keys.clone()}
-                                />
-                            }
-                        },
-                        ControlSpec::NumberFormat => {
-                            let restored_config: CustomNumberFormatConfig = raw_config
-                                .as_ref()
-                                .and_then(|m| m.get("number_format"))
-                                .and_then(|v| serde_json::from_value(v.clone()).ok())
-                                .unwrap_or_default();
-
-                            html! {
-                                <CustomNumberFormat
-                                    {restored_config}
-                                    on_change={on_change.clone()}
-                                    view_type={props.ty.unwrap()}
-                                    column_name={props.column_name.clone()}
-                                    keys={keys.clone()}
-                                />
-                            }
-                        },
-                        ControlSpec::Enum {
-                            key,
-                            variants,
-                            default,
-                        } => {
-                            let current = raw_config
-                                .as_ref()
-                                .and_then(|m| m.get(&key))
-                                .and_then(|v| v.as_str().map(|s| s.to_string()));
-
-                            html! {
-                                <EnumField
-                                    field_key={key}
-                                    {variants}
-                                    {default}
-                                    {current}
-                                    on_change={on_change.clone()}
-                                />
-                            }
-                        },
-                        ControlSpec::Bool { key, default } => {
-                            let current = raw_config
-                                .as_ref()
-                                .and_then(|m| m.get(&key))
-                                .and_then(|v| v.as_bool());
-                            html! {
-                                <BoolField
-                                    field_key={key}
-                                    {default}
-                                    {current}
-                                    on_change={on_change.clone()}
-                                />
-                            }
-                        },
-                        ControlSpec::Color { key, default } => {
-                            let current = raw_config
-                                .as_ref()
-                                .and_then(|m| m.get(&key))
-                                .and_then(|v| v.as_str().map(|s| s.to_string()));
-                            html! {
-                                <ColorField
-                                    field_key={key}
-                                    {default}
-                                    {current}
-                                    named={named_colors.clone()}
-                                    restored={restored.clone()}
-                                    on_pin={on_pin.clone()}
-                                    on_change={on_change.clone()}
-                                />
-                            }
-                        },
-                        ControlSpec::Palette { key, default, max } => {
-                            let current = raw_config
-                                .as_ref()
-                                .and_then(|m| m.get(&key))
-                                .and_then(|v| v.as_str().map(|s| s.to_string()));
-                            html! {
-                                <PaletteField
-                                    field_key={key}
-                                    {default}
-                                    {max}
-                                    {current}
-                                    named={named_palettes.clone()}
-                                    restored={restored.clone()}
-                                    on_pin={on_pin.clone()}
-                                    on_change={on_change.clone()}
-                                />
-                            }
-                        },
-                        ControlSpec::GradientStops {
-                            key,
-                            default,
-                            discrete,
-                        } => {
-                            let current = raw_config
-                                .as_ref()
-                                .and_then(|m| m.get(&key))
-                                .and_then(|v| v.as_str().map(|s| s.to_string()));
-                            html! {
-                                <GradientStopsField
-                                    field_key={key}
-                                    {default}
-                                    {discrete}
-                                    {current}
-                                    named={named_gradients.clone()}
-                                    restored={restored.clone()}
-                                    on_pin={on_pin.clone()}
-                                    on_change={on_change.clone()}
-                                />
-                            }
-                        },
-                        ControlSpec::Number {
-                            key,
-                            default,
-                            min,
-                            max,
-                            step,
-                            include,
-                        } => {
-                            let current = raw_config
-                                .as_ref()
-                                .and_then(|m| m.get(&key))
-                                .and_then(|v| v.as_f64());
-                            html! {
-                                <NumberFieldPrimitive
-                                    field_key={key}
-                                    {default}
-                                    {current}
-                                    {min}
-                                    {max}
-                                    {step}
-                                    {include}
-                                    on_change={on_change.clone()}
-                                />
-                            }
-                        },
-                        ControlSpec::String { .. } => {
-                            return None;
-                        },
-                    };
-
-                    let key = format!("{}::{}", props.column_name, keys.join("+"));
-                    Some(html! { <fieldset class="style-control" {key}>{ component }</fieldset> })
-                })
-                .collect_vec()
-        })
+        .map(|schema| render_specs(schema.fields, &ctx))
         .unwrap_or_else(|error| {
             tracing::error!("{}", error);
             vec![]
@@ -378,4 +165,269 @@ pub fn StyleTab(props: &StyleTabProps) -> Html {
             <div id="column-style-container" class="tab-section">{ components }</div>
         </div>
     }
+}
+
+fn deser_sub<T: serde::de::DeserializeOwned>(
+    raw: &Option<serde_json::Map<String, serde_json::Value>>,
+) -> Option<T> {
+    raw.as_ref()
+        .and_then(|m| serde_json::from_value::<T>(serde_json::Value::Object(m.clone())).ok())
+}
+
+struct FieldRenderCtx<'a> {
+    props: &'a StyleTabProps,
+    raw_config: &'a Option<serde_json::Map<String, serde_json::Value>>,
+    on_change: &'a Callback<ColumnConfigFieldUpdate>,
+    on_group_toggle: &'a Callback<(String, bool)>,
+    on_pin: &'a Callback<(CssKind, String)>,
+    named_colors: &'a Rc<Vec<NamedValue>>,
+    named_palettes: &'a Rc<Vec<NamedValue>>,
+    named_gradients: &'a Rc<Vec<NamedValue>>,
+    restored: &'a Rc<BTreeMap<String, String>>,
+}
+
+fn render_specs(specs: Vec<ControlSpec>, ctx: &FieldRenderCtx) -> Vec<Html> {
+    specs
+        .into_iter()
+        .filter_map(|spec| match spec {
+            ControlSpec::Group { key, fields } => {
+                let children = render_specs(fields, ctx);
+                (!children.is_empty()).then(|| {
+                    let open = !ctx
+                        .props
+                        .presentation
+                        .is_control_group_collapsed(&key);
+
+                    html! {
+                        <ControlGroup
+                            key={format!("{}::group::{}", ctx.props.column_name, key)}
+                            group_key={key.clone()}
+                            {open}
+                            on_toggle={ctx.on_group_toggle.clone()}
+                        >
+                            { children }
+                        </ControlGroup>
+                    }
+                })
+            },
+            spec => {
+                let keys: Vec<String> = spec
+                    .serialized_keys()
+                    .into_iter()
+                    .map(|s| s.to_string())
+                    .collect();
+
+                let component = render_leaf(spec, &keys, ctx)?;
+                let key = format!("{}::{}", ctx.props.column_name, keys.join("+"));
+                Some(html! { <fieldset class="style-control" {key}>{ component }</fieldset> })
+            },
+        })
+        .collect_vec()
+}
+
+fn render_leaf(spec: ControlSpec, keys: &[String], ctx: &FieldRenderCtx) -> Option<Html> {
+    let props = ctx.props;
+    let raw_config = ctx.raw_config;
+    let on_change = ctx.on_change;
+    let component = match spec {
+        ControlSpec::AggregateDepth => {
+            let aggregate_depth = raw_config
+                .as_ref()
+                .and_then(|m| m.get("aggregate_depth"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32;
+            html! {
+                <AggregateDepthSelector
+                    group_by_depth={props.group_by_depth}
+                    on_change={on_change.clone()}
+                    column_name={props.column_name.to_owned()}
+                    value={aggregate_depth}
+                    keys={keys.to_vec()}
+                />
+            }
+        },
+        ControlSpec::NumberSeriesStyle {
+            default: default_config,
+        } => {
+            let config: Option<NumberSeriesStyleConfig> = deser_sub(raw_config);
+            html! {
+                <NumberSeriesStyle
+                    {config}
+                    {default_config}
+                    on_change={on_change.clone()}
+                    keys={keys.to_vec()}
+                />
+            }
+        },
+        ControlSpec::DatetimeFormat => {
+            let config: Option<DatetimeColumnStyleConfig> = deser_sub(raw_config);
+            let enable_time_config = props.ty.unwrap() == ColumnType::Datetime;
+            html! {
+                <DatetimeColumnStyle
+                    {enable_time_config}
+                    {config}
+                    on_change={on_change.clone()}
+                    keys={keys.to_vec()}
+                />
+            }
+        },
+        ControlSpec::StringFormat => {
+            let config: Option<StringColumnStyleConfig> = deser_sub(raw_config);
+            html! {
+                <StringColumnStyle {config} on_change={on_change.clone()} keys={keys.to_vec()} />
+            }
+        },
+        ControlSpec::Symbols {
+            default: default_config,
+        } => {
+            let restored_config: HashMap<String, String> = raw_config
+                .as_ref()
+                .and_then(|m| m.get("symbols"))
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or_default();
+
+            html! {
+                <SymbolStyle
+                    {default_config}
+                    restored_config={Some(restored_config)}
+                    on_change={on_change.clone()}
+                    column_name={props.column_name.clone()}
+                    selected_theme={props.selected_theme.clone()}
+                    session={props.session.clone()}
+                    keys={keys.to_vec()}
+                />
+            }
+        },
+        ControlSpec::NumberFormat => {
+            let restored_config: CustomNumberFormatConfig = raw_config
+                .as_ref()
+                .and_then(|m| m.get("number_format"))
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or_default();
+
+            html! {
+                <CustomNumberFormat
+                    {restored_config}
+                    on_change={on_change.clone()}
+                    view_type={props.ty.unwrap()}
+                    column_name={props.column_name.clone()}
+                    keys={keys.to_vec()}
+                />
+            }
+        },
+        ControlSpec::Enum {
+            key,
+            variants,
+            default,
+        } => {
+            let current = raw_config
+                .as_ref()
+                .and_then(|m| m.get(&key))
+                .and_then(|v| v.as_str().map(|s| s.to_string()));
+
+            html! {
+                <EnumField
+                    field_key={key}
+                    {variants}
+                    {default}
+                    {current}
+                    on_change={on_change.clone()}
+                />
+            }
+        },
+        ControlSpec::Bool { key, default } => {
+            let current = raw_config
+                .as_ref()
+                .and_then(|m| m.get(&key))
+                .and_then(|v| v.as_bool());
+            html! { <BoolField field_key={key} {default} {current} on_change={on_change.clone()} /> }
+        },
+        ControlSpec::Color { key, default } => {
+            let current = raw_config
+                .as_ref()
+                .and_then(|m| m.get(&key))
+                .and_then(|v| v.as_str().map(|s| s.to_string()));
+            html! {
+                <ColorField
+                    field_key={key}
+                    {default}
+                    {current}
+                    named={ctx.named_colors.clone()}
+                    restored={ctx.restored.clone()}
+                    on_pin={ctx.on_pin.clone()}
+                    on_change={on_change.clone()}
+                />
+            }
+        },
+        ControlSpec::Palette { key, default, max } => {
+            let current = raw_config
+                .as_ref()
+                .and_then(|m| m.get(&key))
+                .and_then(|v| v.as_str().map(|s| s.to_string()));
+            html! {
+                <PaletteField
+                    field_key={key}
+                    {default}
+                    {max}
+                    {current}
+                    named={ctx.named_palettes.clone()}
+                    restored={ctx.restored.clone()}
+                    on_pin={ctx.on_pin.clone()}
+                    on_change={on_change.clone()}
+                />
+            }
+        },
+        ControlSpec::GradientStops {
+            key,
+            default,
+            discrete,
+        } => {
+            let current = raw_config
+                .as_ref()
+                .and_then(|m| m.get(&key))
+                .and_then(|v| v.as_str().map(|s| s.to_string()));
+            html! {
+                <GradientStopsField
+                    field_key={key}
+                    {default}
+                    {discrete}
+                    {current}
+                    named={ctx.named_gradients.clone()}
+                    restored={ctx.restored.clone()}
+                    on_pin={ctx.on_pin.clone()}
+                    on_change={on_change.clone()}
+                />
+            }
+        },
+        ControlSpec::Number {
+            key,
+            default,
+            min,
+            max,
+            step,
+            include,
+        } => {
+            let current = raw_config
+                .as_ref()
+                .and_then(|m| m.get(&key))
+                .and_then(|v| v.as_f64());
+            html! {
+                <NumberFieldPrimitive
+                    field_key={key}
+                    {default}
+                    {current}
+                    {min}
+                    {max}
+                    {step}
+                    {include}
+                    on_change={on_change.clone()}
+                />
+            }
+        },
+        ControlSpec::String { .. } | ControlSpec::Group { .. } => {
+            return None;
+        },
+    };
+
+    Some(component)
 }

--- a/rust/perspective-viewer/src/rust/components/containers/control_group.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/control_group.rs
@@ -1,0 +1,91 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+use wasm_bindgen::JsCast;
+use web_sys::{Event, MouseEvent};
+use yew::{Callback, Html, Properties, function_component, html, use_callback, use_mut_ref};
+
+#[derive(Properties, PartialEq)]
+pub struct ControlGroupProps {
+    pub group_key: String,
+
+    pub open: bool,
+
+    pub on_toggle: Callback<(String, bool)>,
+
+    pub children: Html,
+}
+
+#[function_component]
+pub fn ControlGroup(props: &ControlGroupProps) -> Html {
+    let ontoggle = use_callback(
+        (props.group_key.clone(), props.on_toggle.clone()),
+        |event: Event, (group_key, on_toggle)| {
+            if let Some(el) = event
+                .target()
+                .and_then(|x| x.dyn_into::<web_sys::Element>().ok())
+            {
+                on_toggle.emit((group_key.clone(), el.has_attribute("open")));
+            }
+        },
+    );
+
+    let onclick = use_callback((), |event: MouseEvent, _| {
+        if !event.shift_key() {
+            return;
+        }
+
+        event.prevent_default();
+        let Some(details) = event
+            .target()
+            .and_then(|x| x.dyn_into::<web_sys::Element>().ok())
+            .and_then(|x| x.closest("details.control-group").ok().flatten())
+        else {
+            return;
+        };
+
+        let Some(scope) = details.closest(".tab-section").ok().flatten() else {
+            return;
+        };
+
+        let expand = !details.has_attribute("open");
+        let Ok(groups) = scope.query_selector_all("details.control-group") else {
+            return;
+        };
+
+        for i in 0..groups.length() {
+            let Some(el) = groups
+                .item(i)
+                .and_then(|x| x.dyn_into::<web_sys::Element>().ok())
+            else {
+                continue;
+            };
+
+            if expand {
+                let _ = el.set_attribute("open", "");
+            } else {
+                let _ = el.remove_attribute("open");
+            }
+        }
+    });
+
+    let open = *use_mut_ref(|| props.open).borrow();
+    html! {
+        <details class="control-group" {open} {ontoggle}>
+            <summary {onclick}>
+                <span class="control-group-chevron shift-alt-icon" />
+                <label id={format!("{}-group-label", props.group_key)} />
+            </summary>
+            { props.children.clone() }
+        </details>
+    }
+}

--- a/rust/perspective-viewer/src/rust/components/containers/mod.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/mod.rs
@@ -13,6 +13,7 @@
 //! `containers` are generic container-like components for collections of other
 //! `Component` types.
 
+pub mod control_group;
 pub mod dragdrop_list;
 pub mod dropdown_menu;
 pub mod scroll_panel;

--- a/rust/perspective-viewer/src/rust/components/containers/select.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/select.rs
@@ -230,9 +230,15 @@ where
                 <label>
                     { ctx.props().label.as_ref().map(|x| x.to_string()).unwrap_or_default() }
                 </label>
-                <div class={wrapper_class} data-value={value}>{ select }</div>
+                <div class={wrapper_class} data-value={value}>
+                    { select }
+                    <span class="select-arrow" />
+                </div>
             } else {
-                <div class={wrapper_class} data-value={value}>{ select }</div>
+                <div class={wrapper_class} data-value={value}>
+                    { select }
+                    <span class="select-arrow" />
+                </div>
             }
         }
     }

--- a/rust/perspective-viewer/src/rust/components/datetime_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/datetime_column_style.rs
@@ -38,6 +38,9 @@ pub struct DatetimeColumnStyleProps {
     pub enable_time_config: bool,
     pub config: Option<DatetimeColumnStyleConfig>,
 
+    /// The active plugin's declared default `date_format`.
+    pub default_format: Rc<DatetimeFormatType>,
+
     #[prop_or_default]
     pub on_change: Callback<ColumnConfigFieldUpdate>,
 
@@ -57,7 +60,9 @@ impl ModalLink<DatetimeColumnStyle> for DatetimeColumnStyleProps {
 
 impl PartialEq for DatetimeColumnStyleProps {
     fn eq(&self, other: &Self) -> bool {
-        self.enable_time_config == other.enable_time_config && self.config == other.config
+        self.enable_time_config == other.enable_time_config
+            && self.config == other.config
+            && self.default_format == other.default_format
     }
 }
 
@@ -90,7 +95,9 @@ impl Component for DatetimeColumnStyle {
             std::mem::swap(&mut self.config, &mut new_config);
             rerender = true;
         }
-        if old.enable_time_config != ctx.props().enable_time_config {
+        if old.enable_time_config != ctx.props().enable_time_config
+            || old.default_format != ctx.props().default_format
+        {
             rerender = true;
         }
         rerender
@@ -99,22 +106,24 @@ impl Component for DatetimeColumnStyle {
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             DatetimeColumnStyleMsg::TimezoneChanged(val) => {
+                let mut format = self.effective_format(ctx);
                 if Some(&*USER_TIMEZONE) != val.as_ref() {
-                    *self.config.date_format.time_zone_mut() = val;
+                    *format.time_zone_mut() = val;
                 } else {
-                    *self.config.date_format.time_zone_mut() = None;
+                    *format.time_zone_mut() = None;
                 }
 
+                self.set_format(ctx, format);
                 self.dispatch_config(ctx);
                 true
             },
             DatetimeColumnStyleMsg::SimpleDatetimeStyleConfigChanged(simple) => {
-                self.config.date_format = DatetimeFormatType::Simple(simple);
+                self.set_format(ctx, DatetimeFormatType::Simple(simple));
                 self.dispatch_config(ctx);
                 true
             },
             DatetimeColumnStyleMsg::CustomDatetimeStyleConfigChanged(custom) => {
-                self.config.date_format = DatetimeFormatType::Custom(custom);
+                self.set_format(ctx, DatetimeFormatType::Custom(custom));
                 self.dispatch_config(ctx);
                 true
             },
@@ -122,6 +131,24 @@ impl Component for DatetimeColumnStyle {
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {
+        let format = self.effective_format(ctx);
+        let (date_style_default, time_style_default) = match &*ctx.props().default_format {
+            DatetimeFormatType::Simple(simple) => (simple.date_style, simple.time_style),
+            DatetimeFormatType::Custom(_) => {
+                (SimpleDatetimeFormat::Short, SimpleDatetimeFormat::Medium)
+            },
+        };
+
+        let simple_reset = {
+            let default_format = ctx.props().default_format.clone();
+            ctx.link().callback(move |_| {
+                DatetimeColumnStyleMsg::SimpleDatetimeStyleConfigChanged(match &*default_format {
+                    DatetimeFormatType::Simple(simple) => simple.clone(),
+                    DatetimeFormatType::Custom(_) => SimpleDatetimeStyleConfig::default(),
+                })
+            })
+        };
+
         html! {
             <>
                 <div id="column-style-container" class="datetime-column-style-container">
@@ -131,10 +158,10 @@ impl Component for DatetimeColumnStyle {
                             values={ALL_TIMEZONES.with(|x| (*x).clone())}
                             default_value={(*USER_TIMEZONE).clone()}
                             on_change={ctx.link().callback(DatetimeColumnStyleMsg::TimezoneChanged)}
-                            current_value={self.config.date_format.time_zone().as_ref().unwrap_or(&*USER_TIMEZONE).clone()}
+                            current_value={format.time_zone().as_ref().unwrap_or(&*USER_TIMEZONE).clone()}
                         />
                     }
-                    if let DatetimeFormatType::Simple(config) = &self.config.date_format {
+                    if let DatetimeFormatType::Simple(config) = &format {
                         if ctx.props().enable_time_config {
                             <div class="row">
                                 <button
@@ -149,15 +176,17 @@ impl Component for DatetimeColumnStyle {
                             enable_time_config={ctx.props().enable_time_config}
                             on_change={ctx.link().callback(DatetimeColumnStyleMsg::SimpleDatetimeStyleConfigChanged)}
                             config={config.clone()}
+                            {date_style_default}
+                            {time_style_default}
                         />
-                    } else if let DatetimeFormatType::Custom(config) = &self.config.date_format {
+                    } else if let DatetimeFormatType::Custom(config) = &format {
                         if ctx.props().enable_time_config {
                             <div class="row">
                                 <button
                                     id="datetime_format"
                                     data-title="Custom"
                                     data-title-hover="Switch to Simple"
-                                    onclick={ctx.link().callback(|_| DatetimeColumnStyleMsg::SimpleDatetimeStyleConfigChanged(SimpleDatetimeStyleConfig::default()))}
+                                    onclick={simple_reset}
                                 />
                             </div>
                         }
@@ -201,6 +230,17 @@ static USER_TIMEZONE: LazyLock<String> = LazyLock::new(|| {
 });
 
 impl DatetimeColumnStyle {
+    fn effective_format(&self, ctx: &Context<Self>) -> DatetimeFormatType {
+        self.config
+            .date_format
+            .clone()
+            .unwrap_or_else(|| (*ctx.props().default_format).clone())
+    }
+
+    fn set_format(&mut self, ctx: &Context<Self>, format: DatetimeFormatType) {
+        self.config.date_format = (format != *ctx.props().default_format).then_some(format);
+    }
+
     /// When this config has changed, we must signal the wrapper element.
     fn dispatch_config(&self, ctx: &Context<Self>) {
         let value = if self.config == DatetimeColumnStyleConfig::default() {

--- a/rust/perspective-viewer/src/rust/components/datetime_column_style/simple.rs
+++ b/rust/perspective-viewer/src/rust/components/datetime_column_style/simple.rs
@@ -22,6 +22,13 @@ pub struct DatetimeStyleSimpleProps {
     pub enable_time_config: bool,
     pub config: SimpleDatetimeStyleConfig,
 
+    /// The plugin-declared default preset for each style select.
+    #[prop_or(SimpleDatetimeFormat::Short)]
+    pub date_style_default: SimpleDatetimeFormat,
+
+    #[prop_or(SimpleDatetimeFormat::Medium)]
+    pub time_style_default: SimpleDatetimeFormat,
+
     #[prop_or_default]
     pub on_change: Callback<SimpleDatetimeStyleConfig>,
 
@@ -37,7 +44,10 @@ impl ModalLink<DatetimeStyleSimple> for DatetimeStyleSimpleProps {
 
 impl PartialEq for DatetimeStyleSimpleProps {
     fn eq(&self, other: &Self) -> bool {
-        self.enable_time_config == other.enable_time_config && self.config == other.config
+        self.enable_time_config == other.enable_time_config
+            && self.config == other.config
+            && self.date_style_default == other.date_style_default
+            && self.time_style_default == other.time_style_default
     }
 }
 
@@ -69,12 +79,12 @@ impl Component for DatetimeStyleSimple {
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             DatetimeStyleSimpleMsg::DateStyleChanged(format) => {
-                self.config.date_style = format.unwrap_or_default();
+                self.config.date_style = format.unwrap_or(ctx.props().date_style_default);
                 self.dispatch_config(ctx);
                 true
             },
             DatetimeStyleSimpleMsg::TimeStyleChanged(format) => {
-                self.config.time_style = format.unwrap_or_default();
+                self.config.time_style = format.unwrap_or(ctx.props().time_style_default);
                 self.dispatch_config(ctx);
                 true
             },
@@ -99,13 +109,14 @@ impl Component for DatetimeStyleSimple {
                     label="date-style"
                     on_change={ctx.link().callback(DatetimeStyleSimpleMsg::DateStyleChanged)}
                     current_value={self.config.date_style}
+                    default_value={ctx.props().date_style_default}
                 />
                 if ctx.props().enable_time_config {
                     <SelectEnumField<SimpleDatetimeFormat>
                         label="time-style"
                         on_change={ctx.link().callback(DatetimeStyleSimpleMsg::TimeStyleChanged)}
                         current_value={self.config.time_style}
-                        default_value={SimpleDatetimeFormat::Medium}
+                        default_value={ctx.props().time_style_default}
                     />
                 }
             </>

--- a/rust/perspective-viewer/src/rust/components/plugin_tab.rs
+++ b/rust/perspective-viewer/src/rust/components/plugin_tab.rs
@@ -140,7 +140,8 @@ fn render_specs(
                             key={format!("group::{key}")}
                             group_key={key.clone()}
                             open={!presentation.is_control_group_collapsed(key)}
-                            on_toggle={on_group_toggle.clone()}>
+                            on_toggle={on_group_toggle.clone()}
+                        >
                             { children }
                         </ControlGroup>
                     }

--- a/rust/perspective-viewer/src/rust/components/plugin_tab.rs
+++ b/rust/perspective-viewer/src/rust/components/plugin_tab.rs
@@ -219,10 +219,10 @@ fn render_leaf(
         ControlSpec::Group { .. }
         | ControlSpec::AggregateDepth
         | ControlSpec::NumberSeriesStyle { .. }
-        | ControlSpec::DatetimeFormat
+        | ControlSpec::DatetimeFormat { .. }
         | ControlSpec::StringFormat
         | ControlSpec::Symbols { .. }
-        | ControlSpec::NumberFormat
+        | ControlSpec::NumberFormat { .. }
         | ControlSpec::String { .. }
         | ControlSpec::Palette { .. }
         | ControlSpec::GradientStops { .. } => None,

--- a/rust/perspective-viewer/src/rust/components/plugin_tab.rs
+++ b/rust/perspective-viewer/src/rust/components/plugin_tab.rs
@@ -22,7 +22,9 @@ use yew::prelude::*;
 use crate::components::column_settings_sidebar::style_tab::primitive_field::{
     BoolField, ColorField, EnumField, NumberFieldPrimitive,
 };
+use crate::components::containers::control_group::ControlGroup;
 use crate::config::ControlSpec;
+use crate::presentation::Presentation;
 use crate::queries::get_plugin_config_schema;
 use crate::renderer::Renderer;
 use crate::session::Session;
@@ -47,6 +49,7 @@ pub struct PluginTabProps {
     pub plugin_config: PtrEqRc<serde_json::Map<String, serde_json::Value>>,
 
     // State
+    pub presentation: Presentation,
     pub renderer: Renderer,
     pub session: Session,
 }
@@ -95,98 +98,132 @@ pub fn PluginTab(props: &PluginTabProps) -> Html {
         })
     };
 
-    let raw_config = &*props.plugin_config;
-    let components = schema
-        .iter()
-        .cloned()
-        .filter_map(|spec| {
-            let component = match spec {
-                ControlSpec::Enum {
-                    key,
-                    variants,
-                    default,
-                } => {
-                    let current = raw_config
-                        .get(&key)
-                        .and_then(|v| v.as_str().map(|s| s.to_string()));
-                    html! {
-                        <EnumField
-                            field_key={key}
-                            {variants}
-                            {default}
-                            {current}
-                            on_change={on_change.clone()}
-                        />
-                    }
-                },
-                ControlSpec::Bool { key, default } => {
-                    let current = raw_config.get(&key).and_then(|v| v.as_bool());
-                    html! {
-                        <BoolField
-                            field_key={key}
-                            {default}
-                            {current}
-                            on_change={on_change.clone()}
-                        />
-                    }
-                },
-                ControlSpec::Color { key, default } => {
-                    let current = raw_config
-                        .get(&key)
-                        .and_then(|v| v.as_str().map(|s| s.to_string()));
-                    html! {
-                        <ColorField
-                            field_key={key}
-                            {default}
-                            {current}
-                            on_change={on_change.clone()}
-                        />
-                    }
-                },
-                ControlSpec::Number {
-                    key,
-                    default,
-                    min,
-                    max,
-                    step,
-                    include,
-                } => {
-                    let current = raw_config.get(&key).and_then(|v| v.as_f64());
-                    html! {
-                        <NumberFieldPrimitive
-                            field_key={key}
-                            {default}
-                            {current}
-                            {min}
-                            {max}
-                            {step}
-                            {include}
-                            on_change={on_change.clone()}
-                        />
-                    }
-                },
-                // Column-scoped variants don't apply to
-                // plugin-level config; drop silently.
-                ControlSpec::AggregateDepth
-                | ControlSpec::NumberSeriesStyle { .. }
-                | ControlSpec::DatetimeFormat
-                | ControlSpec::StringFormat
-                | ControlSpec::Symbols { .. }
-                | ControlSpec::NumberFormat
-                | ControlSpec::String { .. }
-                | ControlSpec::Palette { .. }
-                | ControlSpec::GradientStops { .. } => {
-                    return None;
-                },
-            };
-
-            Some(html! { <fieldset class="style-control">{ component }</fieldset> })
+    let on_group_toggle = {
+        let presentation = props.presentation.clone();
+        yew::Callback::from(move |(key, open): (String, bool)| {
+            presentation.set_control_group_collapsed(&key, !open);
         })
-        .collect_vec();
+    };
 
+    let raw_config = &*props.plugin_config;
+    let components = render_specs(
+        &schema,
+        raw_config,
+        &on_change,
+        &props.presentation,
+        &on_group_toggle,
+    );
     html! {
         <div id="plugin-tab" class="sidebar_column scrollable">
             <div id="plugin-config-container" class="tab-section">{ components }</div>
         </div>
+    }
+}
+
+fn render_specs(
+    specs: &[ControlSpec],
+    raw_config: &serde_json::Map<String, serde_json::Value>,
+    on_change: &Callback<crate::config::ColumnConfigFieldUpdate>,
+    presentation: &Presentation,
+    on_group_toggle: &Callback<(String, bool)>,
+) -> Vec<Html> {
+    specs
+        .iter()
+        .filter_map(|spec| match spec {
+            ControlSpec::Group { key, fields } => {
+                let children =
+                    render_specs(fields, raw_config, on_change, presentation, on_group_toggle);
+
+                (!children.is_empty()).then(|| {
+                    html! {
+                        <ControlGroup
+                            key={format!("group::{key}")}
+                            group_key={key.clone()}
+                            open={!presentation.is_control_group_collapsed(key)}
+                            on_toggle={on_group_toggle.clone()}>
+                            { children }
+                        </ControlGroup>
+                    }
+                })
+            },
+            leaf => {
+                let key = leaf.serialized_keys().join("+");
+                let component = render_leaf(leaf, raw_config, on_change)?;
+                Some(html! { <fieldset class="style-control" {key}>{ component }</fieldset> })
+            },
+        })
+        .collect_vec()
+}
+
+fn render_leaf(
+    spec: &ControlSpec,
+    raw_config: &serde_json::Map<String, serde_json::Value>,
+    on_change: &Callback<crate::config::ColumnConfigFieldUpdate>,
+) -> Option<Html> {
+    match spec.clone() {
+        ControlSpec::Enum {
+            key,
+            variants,
+            default,
+        } => {
+            let current = raw_config
+                .get(&key)
+                .and_then(|v| v.as_str().map(|s| s.to_string()));
+            Some(html! {
+                <EnumField
+                    field_key={key}
+                    {variants}
+                    {default}
+                    {current}
+                    on_change={on_change.clone()}
+                />
+            })
+        },
+        ControlSpec::Bool { key, default } => {
+            let current = raw_config.get(&key).and_then(|v| v.as_bool());
+            Some(html! {
+                <BoolField field_key={key} {default} {current} on_change={on_change.clone()} />
+            })
+        },
+        ControlSpec::Color { key, default } => {
+            let current = raw_config
+                .get(&key)
+                .and_then(|v| v.as_str().map(|s| s.to_string()));
+            Some(html! {
+                <ColorField field_key={key} {default} {current} on_change={on_change.clone()} />
+            })
+        },
+        ControlSpec::Number {
+            key,
+            default,
+            min,
+            max,
+            step,
+            include,
+        } => {
+            let current = raw_config.get(&key).and_then(|v| v.as_f64());
+            Some(html! {
+                <NumberFieldPrimitive
+                    field_key={key}
+                    {default}
+                    {current}
+                    {min}
+                    {max}
+                    {step}
+                    {include}
+                    on_change={on_change.clone()}
+                />
+            })
+        },
+        ControlSpec::Group { .. }
+        | ControlSpec::AggregateDepth
+        | ControlSpec::NumberSeriesStyle { .. }
+        | ControlSpec::DatetimeFormat
+        | ControlSpec::StringFormat
+        | ControlSpec::Symbols { .. }
+        | ControlSpec::NumberFormat
+        | ControlSpec::String { .. }
+        | ControlSpec::Palette { .. }
+        | ControlSpec::GradientStops { .. } => None,
     }
 }

--- a/rust/perspective-viewer/src/rust/components/settings_panel.rs
+++ b/rust/perspective-viewer/src/rust/components/settings_panel.rs
@@ -370,6 +370,7 @@ pub fn SettingsPanel(props: &SettingsPanelProps) -> Html {
                 <PluginTab
                     view_config={props.view_config.clone()}
                     plugin_config={props.plugin_config.clone()}
+                    presentation={presentation.clone()}
                     renderer={renderer.clone()}
                     session={session.clone()}
                 // initial_width={width}

--- a/rust/perspective-viewer/src/rust/components/status_bar.rs
+++ b/rust/perspective-viewer/src/rust/components/status_bar.rs
@@ -429,7 +429,6 @@ fn ThemeSelector(props: &ThemeSelectorProps) -> Html {
                             <span class="icon" />
                             <Select<String>
                                 id="theme_selector"
-                                class="invert"
                                 {values}
                                 selected={selected.to_owned()}
                                 on_select={props.on_change.clone()}

--- a/rust/perspective-viewer/src/rust/components/style_controls/number_string_format.rs
+++ b/rust/perspective-viewer/src/rust/components/style_controls/number_string_format.rs
@@ -15,6 +15,8 @@ mod misc_section;
 mod style_section;
 mod types;
 
+use std::rc::Rc;
+
 use perspective_client::config::ColumnType;
 pub use types::*;
 use yew::{Callback, Component, Properties, html};
@@ -27,6 +29,10 @@ pub struct CustomNumberFormatProps {
     pub on_change: Callback<ColumnConfigFieldUpdate>,
     pub view_type: ColumnType,
     pub column_name: String,
+
+    /// Resolved default values for this column under the active plugin.
+    pub defaults: Rc<NumberFormatDefaults>,
+
     #[prop_or_default]
     pub keys: Vec<String>,
 }
@@ -147,25 +153,39 @@ impl Component for CustomNumberFormat {
                 self.config.minimum_integer_digits = val;
             },
             CustomNumberFormatMsg::FracChange(val) => {
+                let defaults = &ctx.props().defaults;
                 self.config.rounding_increment = None;
                 self.config.maximum_fraction_digits = val.map(|(_, val)| {
-                    let min = self.config.minimum_fraction_digits.unwrap_or(2.);
+                    let min = self
+                        .config
+                        .minimum_fraction_digits
+                        .unwrap_or(defaults.fraction.0);
                     val.max(min)
                 });
 
                 self.config.minimum_fraction_digits = val.map(|(val, _)| {
-                    let max = self.config.maximum_fraction_digits.unwrap_or(2.);
+                    let max = self
+                        .config
+                        .maximum_fraction_digits
+                        .unwrap_or(defaults.fraction.1);
                     val.min(max)
                 });
             },
             CustomNumberFormatMsg::SigChange(val) => {
+                let defaults = &ctx.props().defaults;
                 self.config.maximum_significant_digits = val.map(|(_, val)| {
-                    let min = self.config.minimum_significant_digits.unwrap_or(1.);
+                    let min = self
+                        .config
+                        .minimum_significant_digits
+                        .unwrap_or(defaults.significant.0);
                     val.max(min)
                 });
 
                 self.config.minimum_significant_digits = val.map(|(val, _)| {
-                    let max = self.config.maximum_significant_digits.unwrap_or(21.);
+                    let max = self
+                        .config
+                        .maximum_significant_digits
+                        .unwrap_or(defaults.significant.1);
                     val.min(max)
                 });
             },
@@ -191,8 +211,7 @@ impl Component for CustomNumberFormat {
             },
         };
 
-        let is_float = ctx.props().view_type == ColumnType::Float;
-        let filtered_config = self.config.clone().filter_default(is_float);
+        let filtered_config = self.config.clone().filter_default(&ctx.props().defaults);
         let mut value = serde_json::Map::new();
         if filtered_config != CustomNumberFormatConfig::default() {
             value.insert(
@@ -216,20 +235,24 @@ impl Component for CustomNumberFormat {
 
 impl CustomNumberFormat {
     fn initialize(ctx: &yew::prelude::Context<Self>) -> Self {
-        let config = ctx.props().restored_config.clone();
+        let defaults = &ctx.props().defaults;
+        let mut config = ctx.props().restored_config.clone();
+        if config._style.is_none() && defaults.style != NumberFormatStyle::Decimal {
+            config._style = Some(defaults.style.clone());
+        }
+
+        if config._notation.is_none() && defaults.notation != Notation::Standard {
+            config._notation = Some(defaults.notation.clone());
+        }
+
         Self {
             style: config
                 ._style
                 .as_ref()
-                .map(|style| match style {
-                    NumberFormatStyle::Decimal => NumberStyle::Decimal,
-                    NumberFormatStyle::Currency(_) => NumberStyle::Currency,
-                    NumberFormatStyle::Percent => NumberStyle::Percent,
-                    NumberFormatStyle::Unit(_) => NumberStyle::Unit,
-                })
+                .map(NumberStyle::from)
                 .unwrap_or_default(),
+            notation: config._notation.as_ref().map(NotationName::from),
             config,
-            notation: None,
         }
     }
 }

--- a/rust/perspective-viewer/src/rust/components/style_controls/number_string_format/digits_section.rs
+++ b/rust/perspective-viewer/src/rust/components/style_controls/number_string_format/digits_section.rs
@@ -37,7 +37,7 @@ impl CustomNumberFormat {
                     min=1.
                     max=21.
                     step=1.
-                    default=1.
+                    default={ctx.props().defaults.minimum_integer_digits}
                     current_value={self.config.minimum_integer_digits}
                     on_change={ctx.link().callback(CustomNumberFormatMsg::MinimumIntegerDigits)}
                 />
@@ -84,14 +84,23 @@ impl CustomNumberFormat {
     }
 
     fn float_section(&self, ctx: &yew::prelude::Context<Self>) -> yew::prelude::Html {
+        let defaults = &ctx.props().defaults;
         let fractional_value = Some((
-            self.config.minimum_fraction_digits.unwrap_or(2.),
-            self.config.maximum_fraction_digits.unwrap_or(2.),
+            self.config
+                .minimum_fraction_digits
+                .unwrap_or(defaults.fraction.0),
+            self.config
+                .maximum_fraction_digits
+                .unwrap_or(defaults.fraction.1),
         ));
 
         let significant_value = Some((
-            self.config.minimum_significant_digits.unwrap_or(1.),
-            self.config.maximum_significant_digits.unwrap_or(21.),
+            self.config
+                .minimum_significant_digits
+                .unwrap_or(defaults.significant.0),
+            self.config
+                .maximum_significant_digits
+                .unwrap_or(defaults.significant.1),
         ));
 
         html! {
@@ -102,7 +111,7 @@ impl CustomNumberFormat {
                         min=0.
                         max=20.
                         step=1.
-                        default={(2., 2.)}
+                        default={defaults.fraction}
                         current_value={fractional_value}
                         on_change={ctx.link().callback(CustomNumberFormatMsg::FracChange)}
                     />
@@ -113,7 +122,7 @@ impl CustomNumberFormat {
                         min=1.
                         max=21.
                         step=1.
-                        default={(1., 21.)}
+                        default={defaults.significant}
                         current_value={significant_value}
                         on_change={ctx.link().callback(CustomNumberFormatMsg::SigChange)}
                     />
@@ -121,17 +130,20 @@ impl CustomNumberFormat {
                 { self.rounding_increment(ctx) }
                 <SelectEnumField<RoundingPriority>
                     label="rounding-priority"
-                    current_value={self.config.rounding_priority}
+                    current_value={self.config.rounding_priority.unwrap_or(defaults.rounding_priority)}
+                    default_value={defaults.rounding_priority}
                     on_change={ctx.link().callback(CustomNumberFormatMsg::RoundingPriority)}
                 />
                 <SelectEnumField<RoundingMode>
                     label="rounding-mode"
-                    current_value={self.config.rounding_mode}
+                    current_value={self.config.rounding_mode.unwrap_or(defaults.rounding_mode)}
+                    default_value={defaults.rounding_mode}
                     on_change={ctx.link().callback(CustomNumberFormatMsg::RoundingMode)}
                 />
                 <SelectEnumField<TrailingZeroDisplay>
                     label="trailing-zero-display"
-                    current_value={self.config.trailing_zero_display}
+                    current_value={self.config.trailing_zero_display.unwrap_or(defaults.trailing_zero_display)}
+                    default_value={defaults.trailing_zero_display}
                     on_change={ctx.link().callback(CustomNumberFormatMsg::TrailingZero)}
                 />
             </>

--- a/rust/perspective-viewer/src/rust/components/style_controls/number_string_format/misc_section.rs
+++ b/rust/perspective-viewer/src/rust/components/style_controls/number_string_format/misc_section.rs
@@ -32,23 +32,27 @@ impl CustomNumberFormat {
             None
         };
 
+        let defaults = &ctx.props().defaults;
         html! {
             <>
                 <SelectEnumField<NotationName>
                     label="notation"
                     on_change={ctx.link().callback(CustomNumberFormatMsg::NotationChanged)}
                     current_value={self.notation.unwrap_or_default()}
+                    default_value={NotationName::from(&defaults.notation)}
                 />
                 { compact_display_checkbox }
                 <SelectEnumField<UseGrouping>
                     label="use-grouping"
                     on_change={ctx.link().callback(CustomNumberFormatMsg::UseGrouping)}
-                    current_value={self.config.use_grouping.unwrap_or_default()}
+                    current_value={self.config.use_grouping.unwrap_or(defaults.use_grouping)}
+                    default_value={defaults.use_grouping}
                 />
                 <SelectEnumField<SignDisplay>
                     label="sign-display"
                     on_change={ctx.link().callback(CustomNumberFormatMsg::SignDisplay)}
-                    current_value={self.config.sign_display.unwrap_or_default()}
+                    current_value={self.config.sign_display.unwrap_or(defaults.sign_display)}
+                    default_value={defaults.sign_display}
                 />
             </>
         }

--- a/rust/perspective-viewer/src/rust/components/style_controls/number_string_format/style_section.rs
+++ b/rust/perspective-viewer/src/rust/components/style_controls/number_string_format/style_section.rs
@@ -60,6 +60,7 @@ impl CustomNumberFormat {
                 <SelectEnumField<NumberStyle>
                     label="style"
                     current_value={self.style}
+                    default_value={NumberStyle::from(&ctx.props().defaults.style)}
                     on_change={ctx.link().callback(CustomNumberFormatMsg::StyleChanged)}
                 />
                 { section }

--- a/rust/perspective-viewer/src/rust/config/column_config_schema.rs
+++ b/rust/perspective-viewer/src/rust/config/column_config_schema.rs
@@ -15,7 +15,10 @@ use std::collections::HashSet;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::{CssKind, KeyValueOpts, NumberSeriesStyleDefaultConfig};
+use super::{
+    CssKind, CustomNumberFormatConfig, DatetimeFormatType, KeyValueOpts,
+    NumberSeriesStyleDefaultConfig,
+};
 
 /// The full schema for one column at one point in time. Plugins may return
 /// different schemas for the same column based on the column's current
@@ -116,7 +119,12 @@ pub enum ControlSpec {
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         discrete: bool,
     },
-    DatetimeFormat,
+    DatetimeFormat {
+        /// Plugin-declared default `date_format`, shown by the editor in
+        /// unedited fields and elided from serialized configs.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default: Option<DatetimeFormatType>,
+    },
     StringFormat,
     NumberSeriesStyle {
         default: NumberSeriesStyleDefaultConfig,
@@ -124,7 +132,12 @@ pub enum ControlSpec {
     Symbols {
         default: KeyValueOpts,
     },
-    NumberFormat,
+    NumberFormat {
+        /// Plugin-declared default format, keyed like `number_format`
+        /// itself.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default: Option<CustomNumberFormatConfig>,
+    },
     AggregateDepth,
 
     Group {
@@ -194,7 +207,9 @@ impl ColumnConfigSchema {
         fn is_format(spec: &ControlSpec) -> bool {
             matches!(
                 spec,
-                ControlSpec::NumberFormat | ControlSpec::DatetimeFormat | ControlSpec::StringFormat
+                ControlSpec::NumberFormat { .. }
+                    | ControlSpec::DatetimeFormat { .. }
+                    | ControlSpec::StringFormat
             )
         }
 
@@ -284,11 +299,11 @@ impl ControlSpec {
     /// `columns_config` blob passed to `plugin.restore()`.
     pub fn serialized_keys(&self) -> Vec<&str> {
         match self {
-            ControlSpec::DatetimeFormat => vec!["date_format"],
+            ControlSpec::DatetimeFormat { .. } => vec!["date_format"],
             ControlSpec::StringFormat => vec!["format"],
             ControlSpec::NumberSeriesStyle { .. } => vec!["chart_type", "stack"],
             ControlSpec::Symbols { .. } => vec!["symbols"],
-            ControlSpec::NumberFormat => vec!["number_format"],
+            ControlSpec::NumberFormat { .. } => vec!["number_format"],
             ControlSpec::AggregateDepth => vec!["aggregate_depth"],
             ControlSpec::Enum { key, .. }
             | ControlSpec::Bool { key, .. }
@@ -410,7 +425,7 @@ mod tests {
     fn format_controls_group_and_merge() {
         let schema = ColumnConfigSchema {
             fields: vec![
-                ControlSpec::NumberFormat,
+                ControlSpec::NumberFormat { default: None },
                 flag("flag"),
                 ControlSpec::StringFormat,
             ],
@@ -423,7 +438,7 @@ mod tests {
         };
 
         assert_eq!(key, "format");
-        assert!(matches!(fields[0], ControlSpec::NumberFormat));
+        assert!(matches!(fields[0], ControlSpec::NumberFormat { .. }));
         assert!(matches!(fields[1], ControlSpec::StringFormat));
         assert!(matches!(&schema.fields[1], ControlSpec::Bool { .. }));
 
@@ -441,8 +456,10 @@ mod tests {
     fn format_grouping_recurses_but_never_double_wraps() {
         let schema = ColumnConfigSchema {
             fields: vec![
-                group("format", vec![ControlSpec::NumberFormat]),
-                group("styling", vec![flag("x"), ControlSpec::DatetimeFormat]),
+                group("format", vec![ControlSpec::NumberFormat { default: None }]),
+                group("styling", vec![flag("x"), ControlSpec::DatetimeFormat {
+                    default: None,
+                }]),
             ],
         }
         .group_format_controls();
@@ -452,7 +469,7 @@ mod tests {
         };
 
         assert_eq!(key, "format");
-        assert!(matches!(fields[0], ControlSpec::NumberFormat));
+        assert!(matches!(fields[0], ControlSpec::NumberFormat { .. }));
 
         let ControlSpec::Group { fields, .. } = &schema.fields[1] else {
             panic!("expected group");
@@ -461,8 +478,87 @@ mod tests {
         assert!(matches!(
             &fields[1],
             ControlSpec::Group { key, fields }
-                if key == "format" && matches!(fields[0], ControlSpec::DatetimeFormat)
+                if key == "format" && matches!(fields[0], ControlSpec::DatetimeFormat { .. })
         ));
+    }
+
+    #[test]
+    fn format_controls_deserialize_without_default_payload() {
+        let schema: ColumnConfigSchema = serde_json::from_value(json!({
+            "fields": [{ "kind": "NumberFormat" }, { "kind": "DatetimeFormat" }]
+        }))
+        .unwrap();
+
+        assert!(matches!(&schema.fields[0], ControlSpec::NumberFormat {
+            default: None
+        }));
+        assert!(matches!(&schema.fields[1], ControlSpec::DatetimeFormat {
+            default: None
+        }));
+    }
+
+    #[test]
+    fn number_format_default_payload_deserializes_flattened_families() {
+        let schema: ColumnConfigSchema = serde_json::from_value(json!({
+            "fields": [{
+                "kind": "NumberFormat",
+                "default": {
+                    "notation": "compact",
+                    "compactDisplay": "short",
+                    "minimumFractionDigits": 0,
+                    "maximumFractionDigits": 1
+                }
+            }]
+        }))
+        .unwrap();
+
+        let ControlSpec::NumberFormat {
+            default: Some(default),
+        } = &schema.fields[0]
+        else {
+            panic!("expected NumberFormat with default");
+        };
+
+        assert_eq!(
+            default._notation,
+            Some(crate::config::Notation::Compact(
+                crate::config::CompactDisplay::Short
+            ))
+        );
+        assert_eq!(default._style, None);
+        assert_eq!(default.minimum_fraction_digits, Some(0.));
+        assert_eq!(default.maximum_fraction_digits, Some(1.));
+        assert_eq!(
+            schema.active_keys(),
+            HashSet::from(["number_format".to_owned()])
+        );
+    }
+
+    #[test]
+    fn datetime_format_default_payload_deserializes_simple_arm() {
+        let schema: ColumnConfigSchema = serde_json::from_value(json!({
+            "fields": [{
+                "kind": "DatetimeFormat",
+                "default": { "dateStyle": "medium", "timeStyle": "disabled" }
+            }]
+        }))
+        .unwrap();
+
+        let ControlSpec::DatetimeFormat {
+            default: Some(DatetimeFormatType::Simple(simple)),
+        } = &schema.fields[0]
+        else {
+            panic!("expected DatetimeFormat with Simple default");
+        };
+
+        assert_eq!(
+            simple.date_style,
+            crate::config::SimpleDatetimeFormat::Medium
+        );
+        assert_eq!(
+            simple.time_style,
+            crate::config::SimpleDatetimeFormat::Disabled
+        );
     }
 
     #[test]

--- a/rust/perspective-viewer/src/rust/config/column_config_schema.rs
+++ b/rust/perspective-viewer/src/rust/config/column_config_schema.rs
@@ -194,9 +194,7 @@ impl ColumnConfigSchema {
         fn is_format(spec: &ControlSpec) -> bool {
             matches!(
                 spec,
-                ControlSpec::NumberFormat
-                    | ControlSpec::DatetimeFormat
-                    | ControlSpec::StringFormat
+                ControlSpec::NumberFormat | ControlSpec::DatetimeFormat | ControlSpec::StringFormat
             )
         }
 

--- a/rust/perspective-viewer/src/rust/config/column_config_schema.rs
+++ b/rust/perspective-viewer/src/rust/config/column_config_schema.rs
@@ -41,6 +41,21 @@ impl ColumnConfigSchema {
         }
         out
     }
+
+    pub fn leaf_fields(&self) -> Vec<&ControlSpec> {
+        fn collect<'a>(fields: &'a [ControlSpec], out: &mut Vec<&'a ControlSpec>) {
+            for spec in fields {
+                match spec {
+                    ControlSpec::Group { fields, .. } => collect(fields, out),
+                    leaf => out.push(leaf),
+                }
+            }
+        }
+
+        let mut out = vec![];
+        collect(&self.fields, &mut out);
+        out
+    }
 }
 
 /// Discriminated union of widget kinds the viewer can render. Composite
@@ -111,6 +126,12 @@ pub enum ControlSpec {
     },
     NumberFormat,
     AggregateDepth,
+
+    Group {
+        key: String,
+        #[serde(default)]
+        fields: Vec<ControlSpec>,
+    },
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -165,37 +186,90 @@ pub fn discrete_pair(stops: Vec<GradientStopSpec>) -> Vec<GradientStopSpec> {
 }
 
 impl ColumnConfigSchema {
+    pub fn canonicalize(self) -> Self {
+        self.canonicalize_defaults().group_format_controls()
+    }
+
+    pub fn group_format_controls(mut self) -> Self {
+        fn is_format(spec: &ControlSpec) -> bool {
+            matches!(
+                spec,
+                ControlSpec::NumberFormat
+                    | ControlSpec::DatetimeFormat
+                    | ControlSpec::StringFormat
+            )
+        }
+
+        fn walk(fields: &mut Vec<ControlSpec>) {
+            for spec in fields.iter_mut() {
+                if let ControlSpec::Group { key, fields } = spec
+                    && key != "format"
+                {
+                    walk(fields);
+                }
+            }
+
+            let first = fields.iter().position(is_format);
+            if let Some(first) = first {
+                let mut formats = vec![];
+                let mut i = first;
+                while i < fields.len() {
+                    if is_format(&fields[i]) {
+                        formats.push(fields.remove(i));
+                    } else {
+                        i += 1;
+                    }
+                }
+
+                fields.insert(first, ControlSpec::Group {
+                    key: "format".to_owned(),
+                    fields: formats,
+                });
+            }
+        }
+
+        walk(&mut self.fields);
+        self
+    }
+
     /// Canonicalize every CSS-valued default at schema ingest, dropping
     /// (and logging) fields whose default fails its kind's reader.
     pub fn canonicalize_defaults(mut self) -> Self {
-        self.fields.retain_mut(|spec| {
-            let (kind, key, default) = match spec {
-                ControlSpec::Color { key, default } => (CssKind::Color, key, default),
-                ControlSpec::Palette { key, default, .. } => (CssKind::Palette, key, default),
-                ControlSpec::GradientStops { key, default, .. } => {
-                    (CssKind::Gradient, key, default)
-                },
-                _ => return true,
-            };
+        fn canonicalize_specs(fields: &mut Vec<ControlSpec>) {
+            fields.retain_mut(|spec| {
+                let (kind, key, default) = match spec {
+                    ControlSpec::Group { fields, .. } => {
+                        canonicalize_specs(fields);
+                        return !fields.is_empty();
+                    },
+                    ControlSpec::Color { key, default } => (CssKind::Color, key, default),
+                    ControlSpec::Palette { key, default, .. } => (CssKind::Palette, key, default),
+                    ControlSpec::GradientStops { key, default, .. } => {
+                        (CssKind::Gradient, key, default)
+                    },
+                    _ => return true,
+                };
 
-            match kind.canonicalize(default) {
-                Ok(canonical) => {
-                    *default = canonical;
-                    true
-                },
-                Err(error) => {
-                    tracing::error!("Dropping `{key}` — invalid schema default: {error}");
-                    false
-                },
-            }
-        });
+                match kind.canonicalize(default) {
+                    Ok(canonical) => {
+                        *default = canonical;
+                        true
+                    },
+                    Err(error) => {
+                        tracing::error!("Dropping `{key}` — invalid schema default: {error}");
+                        false
+                    },
+                }
+            });
+        }
 
+        canonicalize_specs(&mut self.fields);
         self
     }
 
     /// The CSS kind of the control owning `key`, if it is CSS-valued.
     pub fn css_kind_of(&self, key: &str) -> Option<CssKind> {
-        self.fields.iter().find_map(|spec| match spec {
+        self.leaf_fields().into_iter().find_map(|spec| match spec {
             ControlSpec::Color { key: k, .. } if k == key => Some(CssKind::Color),
             ControlSpec::Palette { key: k, .. } if k == key => Some(CssKind::Palette),
             ControlSpec::GradientStops { key: k, .. } if k == key => Some(CssKind::Gradient),
@@ -225,6 +299,9 @@ impl ControlSpec {
             | ControlSpec::Color { key, .. }
             | ControlSpec::Palette { key, .. }
             | ControlSpec::GradientStops { key, .. } => vec![key.as_str()],
+            ControlSpec::Group { fields, .. } => {
+                fields.iter().flat_map(|f| f.serialized_keys()).collect()
+            },
         }
     }
 }
@@ -251,4 +328,164 @@ pub fn filter_to_schema(
         .filter(|(k, _)| active_keys.contains(k.as_str()))
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn color(key: &str, default: &str) -> ControlSpec {
+        ControlSpec::Color {
+            key: key.to_owned(),
+            default: default.to_owned(),
+        }
+    }
+
+    fn flag(key: &str) -> ControlSpec {
+        ControlSpec::Bool {
+            key: key.to_owned(),
+            default: false,
+        }
+    }
+
+    fn group(key: &str, fields: Vec<ControlSpec>) -> ControlSpec {
+        ControlSpec::Group {
+            key: key.to_owned(),
+            fields,
+        }
+    }
+
+    #[test]
+    fn group_deserializes_recursively() {
+        let schema: ColumnConfigSchema = serde_json::from_value(json!({
+            "fields": [{
+                "kind": "Group",
+                "key": "legend",
+                "fields": [
+                    { "kind": "Bool", "key": "legend_on", "default": false },
+                    {
+                        "kind": "Group",
+                        "key": "inner",
+                        "fields": [{ "kind": "Color", "key": "color", "default": "#ff0000" }]
+                    }
+                ]
+            }]
+        }))
+        .unwrap();
+
+        let keys = schema.active_keys();
+        assert_eq!(
+            keys,
+            HashSet::from(["legend_on".to_owned(), "color".to_owned()])
+        );
+
+        let leaves = schema.leaf_fields();
+        assert_eq!(leaves.len(), 2);
+        assert!(
+            leaves
+                .iter()
+                .all(|s| !matches!(s, ControlSpec::Group { .. }))
+        );
+    }
+
+    #[test]
+    fn grouped_schema_is_equivalent_to_flat() {
+        let flat = ColumnConfigSchema {
+            fields: vec![flag("stack"), color("color", "#0366d6")],
+        };
+
+        let grouped = ColumnConfigSchema {
+            fields: vec![group("series", vec![
+                flag("stack"),
+                color("color", "#0366d6"),
+            ])],
+        };
+
+        assert_eq!(flat.active_keys(), grouped.active_keys());
+        assert_eq!(flat.css_kind_of("color"), grouped.css_kind_of("color"));
+        assert_eq!(flat.css_kind_of("stack"), grouped.css_kind_of("stack"));
+    }
+
+    #[test]
+    fn format_controls_group_and_merge() {
+        let schema = ColumnConfigSchema {
+            fields: vec![
+                ControlSpec::NumberFormat,
+                flag("flag"),
+                ControlSpec::StringFormat,
+            ],
+        }
+        .group_format_controls();
+
+        assert_eq!(schema.fields.len(), 2);
+        let ControlSpec::Group { key, fields } = &schema.fields[0] else {
+            panic!("expected format group first");
+        };
+
+        assert_eq!(key, "format");
+        assert!(matches!(fields[0], ControlSpec::NumberFormat));
+        assert!(matches!(fields[1], ControlSpec::StringFormat));
+        assert!(matches!(&schema.fields[1], ControlSpec::Bool { .. }));
+
+        assert_eq!(
+            schema.active_keys(),
+            HashSet::from([
+                "number_format".to_owned(),
+                "format".to_owned(),
+                "flag".to_owned()
+            ])
+        );
+    }
+
+    #[test]
+    fn format_grouping_recurses_but_never_double_wraps() {
+        let schema = ColumnConfigSchema {
+            fields: vec![
+                group("format", vec![ControlSpec::NumberFormat]),
+                group("styling", vec![flag("x"), ControlSpec::DatetimeFormat]),
+            ],
+        }
+        .group_format_controls();
+
+        let ControlSpec::Group { key, fields } = &schema.fields[0] else {
+            panic!("expected group");
+        };
+
+        assert_eq!(key, "format");
+        assert!(matches!(fields[0], ControlSpec::NumberFormat));
+
+        let ControlSpec::Group { fields, .. } = &schema.fields[1] else {
+            panic!("expected group");
+        };
+
+        assert!(matches!(
+            &fields[1],
+            ControlSpec::Group { key, fields }
+                if key == "format" && matches!(fields[0], ControlSpec::DatetimeFormat)
+        ));
+    }
+
+    #[test]
+    fn canonicalize_defaults_recurses_and_drops_empty_groups() {
+        let schema = ColumnConfigSchema {
+            fields: vec![
+                group("ok", vec![color("good", "RGB(255,0,0)"), flag("flag")]),
+                group("doomed", vec![color("bad", "not-a-color")]),
+            ],
+        }
+        .canonicalize_defaults();
+
+        assert_eq!(schema.fields.len(), 1);
+        let ControlSpec::Group { key, fields } = &schema.fields[0] else {
+            panic!("expected group");
+        };
+
+        assert_eq!(key, "ok");
+        assert!(matches!(
+            &fields[0],
+            ControlSpec::Color { default, .. } if default == "#ff0000"
+        ));
+    }
 }

--- a/rust/perspective-viewer/src/rust/config/datetime_column_style.rs
+++ b/rust/perspective-viewer/src/rust/config/datetime_column_style.rs
@@ -41,10 +41,6 @@ impl Default for DatetimeFormatType {
 }
 
 impl DatetimeFormatType {
-    fn is_simple(&self) -> bool {
-        self == &Self::Simple(SimpleDatetimeStyleConfig::default())
-    }
-
     pub fn time_zone(&self) -> &Option<String> {
         match self {
             DatetimeFormatType::Custom(x) => &x.time_zone,
@@ -62,12 +58,13 @@ impl DatetimeFormatType {
 
 /// A model for the JSON serialized style configuration for a column of type
 /// `datetime`.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, TS)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, TS)]
 // #[derive(WasmDescribe!, FromWasmAbi!)]
 pub struct DatetimeColumnStyleConfig {
     #[serde(default)]
-    #[serde(skip_serializing_if = "DatetimeFormatType::is_simple")]
-    pub date_format: DatetimeFormatType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, as = "Option<_>")]
+    pub date_format: Option<DatetimeFormatType>,
 
     #[serde(default)]
     #[serde(skip_serializing_if = "DatetimeColorMode::is_none")]
@@ -77,18 +74,4 @@ pub struct DatetimeColumnStyleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(skip)]
     pub color: Option<String>,
-}
-
-impl Default for DatetimeColumnStyleConfig {
-    fn default() -> Self {
-        Self {
-            date_format: DatetimeFormatType::Simple(SimpleDatetimeStyleConfig {
-                time_zone: Default::default(),
-                date_style: SimpleDatetimeFormat::Short,
-                time_style: SimpleDatetimeFormat::Medium,
-            }),
-            datetime_color_mode: Default::default(),
-            color: Default::default(),
-        }
-    }
 }

--- a/rust/perspective-viewer/src/rust/config/number_string_format.rs
+++ b/rust/perspective-viewer/src/rust/config/number_string_format.rs
@@ -302,7 +302,7 @@ impl CustomNumberFormatConfig {
             minimum_significant_digits: show_sig
                 .then_some(minimum_significant_digits.unwrap_or(1.)),
             maximum_significant_digits: show_sig
-                .then_some(minimum_significant_digits.unwrap_or(21.)),
+                .then_some(maximum_significant_digits.unwrap_or(21.)),
             rounding_priority: self
                 .rounding_priority
                 .filter(|val| *val != RoundingPriority::default()),

--- a/rust/perspective-viewer/src/rust/config/number_string_format.rs
+++ b/rust/perspective-viewer/src/rust/config/number_string_format.rs
@@ -255,13 +255,106 @@ pub struct CustomNumberFormatConfig {
     pub sign_display: Option<SignDisplay>,
 }
 
+/// The active plugin's `NumberFormat` default overlaid on the built-in
+/// `number_format` values.
+#[derive(Clone, Debug, PartialEq)]
+pub struct NumberFormatDefaults {
+    pub is_float: bool,
+    pub style: NumberFormatStyle,
+    pub notation: Notation,
+    pub minimum_integer_digits: f64,
+    pub fraction: (f64, f64),
+    pub significant: (f64, f64),
+    pub rounding_priority: RoundingPriority,
+    pub rounding_mode: RoundingMode,
+    pub trailing_zero_display: TrailingZeroDisplay,
+    pub use_grouping: UseGrouping,
+    pub sign_display: SignDisplay,
+}
+
+impl NumberFormatDefaults {
+    pub fn builtin(is_float: bool) -> Self {
+        Self {
+            is_float,
+            style: NumberFormatStyle::default(),
+            notation: Notation::default(),
+            minimum_integer_digits: 1.,
+            fraction: if is_float { (2., 2.) } else { (0., 0.) },
+            significant: (1., 21.),
+            rounding_priority: RoundingPriority::default(),
+            rounding_mode: RoundingMode::default(),
+            trailing_zero_display: TrailingZeroDisplay::default(),
+            use_grouping: UseGrouping::default(),
+            sign_display: SignDisplay::default(),
+        }
+    }
+
+    /// Overlay a plugin-declared partial default onto [`Self::builtin`].
+    pub fn resolve(spec_default: Option<&CustomNumberFormatConfig>, is_float: bool) -> Self {
+        let mut out = Self::builtin(is_float);
+        let Some(d) = spec_default else {
+            return out;
+        };
+
+        if let Some(style) = &d._style {
+            out.style = style.clone();
+        }
+
+        if let Some(notation) = &d._notation {
+            out.notation = notation.clone();
+        }
+
+        if let Some(v) = d.minimum_integer_digits {
+            out.minimum_integer_digits = v;
+        }
+
+        if let Some(v) = d.minimum_fraction_digits {
+            out.fraction.0 = v;
+        }
+
+        if let Some(v) = d.maximum_fraction_digits {
+            out.fraction.1 = v;
+        }
+
+        if let Some(v) = d.minimum_significant_digits {
+            out.significant.0 = v;
+        }
+
+        if let Some(v) = d.maximum_significant_digits {
+            out.significant.1 = v;
+        }
+
+        if let Some(v) = d.rounding_priority {
+            out.rounding_priority = v;
+        }
+
+        if let Some(v) = d.rounding_mode {
+            out.rounding_mode = v;
+        }
+
+        if let Some(v) = d.trailing_zero_display {
+            out.trailing_zero_display = v;
+        }
+
+        if let Some(v) = d.use_grouping {
+            out.use_grouping = v;
+        }
+
+        if let Some(v) = d.sign_display {
+            out.sign_display = v;
+        }
+
+        out
+    }
+}
+
 impl CustomNumberFormatConfig {
-    pub fn filter_default(self, is_float: bool) -> Self {
-        let (frac_min, frac_max) = if is_float { (2., 2.) } else { (0., 0.) };
+    pub fn filter_default(self, defaults: &NumberFormatDefaults) -> Self {
+        let (frac_min, frac_max) = defaults.fraction;
         let rounding_increment = self.rounding_increment;
         let use_grouping = self
             .use_grouping
-            .filter(|val| *val != UseGrouping::default());
+            .filter(|val| *val != defaults.use_grouping);
 
         let mut minimum_fraction_digits =
             self.minimum_fraction_digits.filter(|val| *val != frac_min);
@@ -269,7 +362,7 @@ impl CustomNumberFormatConfig {
         let mut maximum_fraction_digits =
             self.maximum_fraction_digits.filter(|val| *val != frac_max);
 
-        let mut show_frac = is_float
+        let mut show_frac = defaults.is_float
             && (minimum_fraction_digits.is_some()
                 || maximum_fraction_digits.is_some()
                 || use_grouping.is_some()
@@ -277,7 +370,7 @@ impl CustomNumberFormatConfig {
                     self._style,
                     Some(NumberFormatStyle::Percent | NumberFormatStyle::Unit(_))
                 ))
-            || !is_float && matches!(self._style, Some(NumberFormatStyle::Currency(_)));
+            || !defaults.is_float && matches!(self._style, Some(NumberFormatStyle::Currency(_)));
 
         // Rounding increment does not work unless `minimum_fraction_digits`
         // and `maximum_fraction_digits` are set to 0.
@@ -287,39 +380,139 @@ impl CustomNumberFormatConfig {
             maximum_fraction_digits = Some(0.);
         }
 
-        let minimum_significant_digits = self.minimum_significant_digits.filter(|val| *val != 1.);
-        let maximum_significant_digits = self.maximum_significant_digits.filter(|val| *val != 21.);
+        let minimum_significant_digits = self
+            .minimum_significant_digits
+            .filter(|val| *val != defaults.significant.0);
+
+        let maximum_significant_digits = self
+            .maximum_significant_digits
+            .filter(|val| *val != defaults.significant.1);
+
         let show_sig = minimum_significant_digits.is_some() || maximum_significant_digits.is_some();
         Self {
-            _style: self
-                ._style
-                .filter(|style| !matches!(style, NumberFormatStyle::Decimal)),
-            minimum_integer_digits: self.minimum_integer_digits.filter(|val| *val != 1.),
+            _style: self._style.filter(|style| *style != defaults.style),
+            minimum_integer_digits: self
+                .minimum_integer_digits
+                .filter(|val| *val != defaults.minimum_integer_digits),
             minimum_fraction_digits: show_frac
                 .then_some(minimum_fraction_digits.unwrap_or(frac_min)),
             maximum_fraction_digits: show_frac
                 .then_some(maximum_fraction_digits.unwrap_or(frac_max)),
             minimum_significant_digits: show_sig
-                .then_some(minimum_significant_digits.unwrap_or(1.)),
+                .then_some(minimum_significant_digits.unwrap_or(defaults.significant.0)),
             maximum_significant_digits: show_sig
-                .then_some(maximum_significant_digits.unwrap_or(21.)),
+                .then_some(maximum_significant_digits.unwrap_or(defaults.significant.1)),
             rounding_priority: self
                 .rounding_priority
-                .filter(|val| *val != RoundingPriority::default()),
+                .filter(|val| *val != defaults.rounding_priority),
             rounding_increment,
             rounding_mode: self
                 .rounding_mode
-                .filter(|val| *val != RoundingMode::default()),
+                .filter(|val| *val != defaults.rounding_mode),
             trailing_zero_display: self
                 .trailing_zero_display
-                .filter(|val| *val != TrailingZeroDisplay::default()),
+                .filter(|val| *val != defaults.trailing_zero_display),
             _notation: self
                 ._notation
-                .filter(|notation| !matches!(notation, Notation::Standard)),
+                .filter(|notation| *notation != defaults.notation),
             use_grouping,
             sign_display: self
                 .sign_display
-                .filter(|val| *val != SignDisplay::default()),
+                .filter(|val| *val != defaults.sign_display),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sig(min: f64, max: f64) -> CustomNumberFormatConfig {
+        CustomNumberFormatConfig {
+            minimum_significant_digits: Some(min),
+            maximum_significant_digits: Some(max),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolve_overlays_partial_default_on_builtin() {
+        let spec = CustomNumberFormatConfig {
+            _notation: Some(Notation::Compact(CompactDisplay::Short)),
+            minimum_fraction_digits: Some(0.),
+            maximum_fraction_digits: Some(1.),
+            ..Default::default()
+        };
+
+        let defaults = NumberFormatDefaults::resolve(Some(&spec), true);
+        assert_eq!(defaults.notation, Notation::Compact(CompactDisplay::Short));
+        assert_eq!(defaults.fraction, (0., 1.));
+        assert_eq!(defaults.style, NumberFormatStyle::Decimal);
+        assert_eq!(defaults.significant, (1., 21.));
+        assert_eq!(
+            NumberFormatDefaults::resolve(None, true),
+            NumberFormatDefaults::builtin(true)
+        );
+    }
+
+    #[test]
+    fn filter_preserves_max_significant_digits() {
+        let filtered = sig(1., 5.).filter_default(&NumberFormatDefaults::builtin(true));
+        assert_eq!(filtered.minimum_significant_digits, Some(1.));
+        assert_eq!(filtered.maximum_significant_digits, Some(5.));
+
+        let filtered = sig(3., 21.).filter_default(&NumberFormatDefaults::builtin(true));
+        assert_eq!(filtered.minimum_significant_digits, Some(3.));
+        assert_eq!(filtered.maximum_significant_digits, Some(21.));
+    }
+
+    #[test]
+    fn filter_elides_values_equal_to_resolved_defaults() {
+        let defaults = NumberFormatDefaults {
+            fraction: (0., 1.),
+            notation: Notation::Compact(CompactDisplay::Short),
+            ..NumberFormatDefaults::builtin(true)
+        };
+
+        let config = CustomNumberFormatConfig {
+            _notation: Some(Notation::Compact(CompactDisplay::Short)),
+            minimum_fraction_digits: Some(0.),
+            maximum_fraction_digits: Some(1.),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            config.filter_default(&defaults),
+            CustomNumberFormatConfig::default()
+        );
+    }
+
+    #[test]
+    fn filter_serializes_builtin_values_under_override() {
+        let defaults = NumberFormatDefaults {
+            notation: Notation::Compact(CompactDisplay::Short),
+            ..NumberFormatDefaults::builtin(true)
+        };
+
+        let config = CustomNumberFormatConfig {
+            _notation: Some(Notation::Standard),
+            ..Default::default()
+        };
+
+        let filtered = config.filter_default(&defaults);
+        assert_eq!(filtered._notation, Some(Notation::Standard));
+    }
+
+    #[test]
+    fn filter_bakes_fraction_digits_for_percent_style() {
+        let config = CustomNumberFormatConfig {
+            _style: Some(NumberFormatStyle::Percent),
+            ..Default::default()
+        };
+
+        let filtered = config.filter_default(&NumberFormatDefaults::builtin(true));
+        assert_eq!(filtered._style, Some(NumberFormatStyle::Percent));
+        assert_eq!(filtered.minimum_fraction_digits, Some(2.));
+        assert_eq!(filtered.maximum_fraction_digits, Some(2.));
     }
 }

--- a/rust/perspective-viewer/src/rust/presentation.rs
+++ b/rust/perspective-viewer/src/rust/presentation.rs
@@ -104,6 +104,8 @@ pub struct PresentationHandle {
     open_column_settings: RefCell<OpenColumnSettings>,
     is_workspace: RefCell<Option<bool>>,
 
+    collapsed_control_groups: RefCell<HashSet<String>>,
+
     /// Drag/drop in-progress state. Empty (`NoDrag`) when no user drag is
     /// active. Mutated by `notify_drag_*` / `notify_drop`; read by component
     /// CSS-class derivations (`is_dragover`, `get_drag_column`).
@@ -191,6 +193,7 @@ impl Presentation {
             on_is_workspace_changed: Default::default(),
             is_settings_open: Default::default(),
             open_column_settings: Default::default(),
+            collapsed_control_groups: Default::default(),
             theme_config_updated: PubSub::default(),
             on_eject: PubSub::default(),
             statusbar_pointer_event: PubSub::default(),
@@ -355,6 +358,20 @@ impl Presentation {
     /// Gets a clone of the current OpenColumnSettings.
     pub fn get_open_column_settings(&self) -> OpenColumnSettings {
         self.open_column_settings.borrow().deref().clone()
+    }
+
+    pub fn is_control_group_collapsed(&self, key: &str) -> bool {
+        self.collapsed_control_groups.borrow().contains(key)
+    }
+
+    pub fn set_control_group_collapsed(&self, key: &str, collapsed: bool) {
+        if collapsed {
+            self.collapsed_control_groups
+                .borrow_mut()
+                .insert(key.to_owned());
+        } else {
+            self.collapsed_control_groups.borrow_mut().remove(key);
+        }
     }
 
     async fn init(self) -> ApiResult<()> {

--- a/rust/perspective-viewer/src/rust/queries/plugin_column_styles.rs
+++ b/rust/perspective-viewer/src/rust/queries/plugin_column_styles.rs
@@ -42,7 +42,7 @@ pub fn get_plugin_config_schema(
         wasm_bindgen::JsValue::from_serde_ext(view_config).unwrap_or(wasm_bindgen::JsValue::NULL);
     let raw = plugin._plugin_config_schema(&view_config_js)?;
     serde_wasm_bindgen::from_value::<ColumnConfigSchema>(raw)
-        .map(|schema| schema.canonicalize_defaults())
+        .map(|schema| schema.canonicalize())
         .map_err(|e| e.into())
 }
 
@@ -100,6 +100,6 @@ pub fn get_column_config_schema(
     )?;
 
     serde_wasm_bindgen::from_value::<ColumnConfigSchema>(raw)
-        .map(|schema| schema.canonicalize_defaults())
+        .map(|schema| schema.canonicalize())
         .map_err(|e| e.into())
 }

--- a/rust/perspective-viewer/src/rust/renderer/plugin_config.rs
+++ b/rust/perspective-viewer/src/rust/renderer/plugin_config.rs
@@ -133,7 +133,7 @@ impl Renderer {
             else {
                 continue;
             };
-            let needs_warm = schema.fields.iter().any(|f| {
+            let needs_warm = schema.leaf_fields().into_iter().any(|f| {
                 matches!(
                     f,
                     ControlSpec::Number {
@@ -164,7 +164,7 @@ impl Renderer {
                 continue;
             };
 
-            for field in &schema.fields {
+            for field in schema.leaf_fields() {
                 let ControlSpec::Number {
                     key,
                     default,
@@ -380,7 +380,7 @@ impl Renderer {
         let view_config_js = JsValue::from_serde_ext(view_config).unwrap_or(JsValue::NULL);
         let raw = plugin._plugin_config_schema(&view_config_js)?;
         serde_wasm_bindgen::from_value::<ColumnConfigSchema>(raw)
-            .map(|schema| schema.canonicalize_defaults())
+            .map(|schema| schema.canonicalize())
             .map_err(|e| e.into())
     }
 
@@ -429,7 +429,7 @@ impl Renderer {
         )?;
 
         serde_wasm_bindgen::from_value::<ColumnConfigSchema>(raw)
-            .map(|schema| schema.canonicalize_defaults())
+            .map(|schema| schema.canonicalize())
             .map_err(|e| e.into())
     }
 
@@ -470,9 +470,9 @@ impl Renderer {
                         ))));
                     }
 
+                    let leaves = s.leaf_fields();
                     map.retain(|key, value| {
-                        let is_default = s
-                            .fields
+                        let is_default = leaves
                             .iter()
                             .any(|spec| matches_declared_default(spec, key, value));
                         if is_default {
@@ -567,9 +567,9 @@ fn strip_default_values(
     schema: &ColumnConfigSchema,
     map: &mut serde_json::Map<String, serde_json::Value>,
 ) {
+    let leaves = schema.leaf_fields();
     map.retain(|key, value| {
-        !schema
-            .fields
+        !leaves
             .iter()
             .any(|spec| matches_declared_default(spec, key, value))
     });
@@ -700,6 +700,53 @@ mod tests {
             "color",
             &json!("var(--psp-user--color-1)")
         ));
+    }
+
+    #[test]
+    fn strip_default_values_sees_through_groups() {
+        let leaves = vec![
+            ControlSpec::Bool {
+                key: "flag".to_owned(),
+                default: false,
+            },
+            ControlSpec::Number {
+                key: "size".to_owned(),
+                default: 3.0,
+                include: None,
+                min: None,
+                max: None,
+                step: None,
+            },
+        ];
+
+        let flat = ColumnConfigSchema {
+            fields: leaves.clone(),
+        };
+
+        let grouped = ColumnConfigSchema {
+            fields: vec![ControlSpec::Group {
+                key: "section".to_owned(),
+                fields: leaves,
+            }],
+        };
+
+        let src = json!({ "flag": false, "size": 4.0, "foreign": 1 })
+            .as_object()
+            .unwrap()
+            .clone();
+
+        let mut a = src.clone();
+        let mut b = src;
+        strip_default_values(&flat, &mut a);
+        strip_default_values(&grouped, &mut b);
+        assert_eq!(a, b);
+        assert_eq!(
+            a,
+            json!({ "size": 4.0, "foreign": 1 })
+                .as_object()
+                .unwrap()
+                .clone()
+        );
     }
 
     #[test]

--- a/rust/perspective-viewer/src/svg/dropdown-selector-light.svg
+++ b/rust/perspective-viewer/src/svg/dropdown-selector-light.svg
@@ -1,3 +1,0 @@
-<svg width="6" height="4" viewBox="0 0 6 4" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1 1L3.17687 3.17687L5.35374 1" stroke="#ffffff" stroke-width="0.725624" stroke-linecap="round"/>
-</svg>

--- a/rust/perspective-viewer/src/themes/blueprint.css
+++ b/rust/perspective-viewer/src/themes/blueprint.css
@@ -1,0 +1,190 @@
+/* ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+ * ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+ * ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+ * ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+ * ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+ * ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+ * ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+ * ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+ * ┃ This file is part of the Perspective library, distributed under the terms ┃
+ * ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+ * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ */
+
+@import "./defaults.css";
+
+perspective-viewer,
+perspective-viewer[theme="Blueprint"],
+perspective-viewer [theme="Blueprint"] {
+    --psp-theme-name: "Blueprint";
+}
+
+perspective-viewer[theme="Blueprint"],
+perspective-viewer [theme="Blueprint"] {
+    --theme-bg0: #0c2f6b;
+    --theme-bg1: #103a80;
+    --theme-bg2: #1b478f;
+    --theme-bg3: #2a58a8;
+
+    --theme-fg0: #e6f0ff;
+    --theme-fg1: #a9c4ee;
+    --theme-fg2: #5b84c6;
+
+    --theme-line: #3b6fc4;
+    --theme-cyan: #7fd3ff;
+    --theme-yellow: #ffd166;
+    --theme-orange: #ff8a65;
+    --theme-green: #b8e986;
+    --theme-pink: #ff9ecf;
+    --theme-white: #ffffff;
+    --theme-lavender: #c3b1ff;
+    --theme-mint: #5ee7c7;
+    --theme-magenta: #f6a6ff;
+    --theme-sky: #9cc3ff;
+
+    background-color: var(--theme-bg0);
+    color: var(--theme-fg0);
+    color-scheme: dark;
+    --psp--color: var(--theme-fg0);
+    --psp-active--color: var(--theme-cyan);
+    --psp-error--color: var(--theme-orange);
+    --psp-inactive--color: var(--theme-fg2);
+    --psp-inactive--border-color: var(--theme-bg3);
+    --psp--background-color: var(--theme-bg0);
+    --psp-active--background: rgba(127, 211, 255, 0.3);
+    --psp-expression--operator--color: var(--theme-fg1);
+    --psp-expression--function--color: var(--theme-cyan);
+    --psp-expression--psp-error--color: var(--theme-orange);
+    --psp-calendar--filter: invert(1);
+    --psp-input--filter: invert(1);
+    --psp-warning--color: var(--theme-bg0);
+    --psp-warning--background: var(--theme-yellow);
+
+    --psp-status-icon--connected--color: var(--theme-green);
+    --psp-status-icon--initializing--color: var(--theme-yellow);
+    --psp-status-icon--psp-error--color: var(--theme-orange);
+
+    --psp-code-editor--symbol--color: var(--theme-fg0);
+    --psp-code-editor--literal--color: var(--theme-cyan);
+    --psp-code-editor--operator--color: var(--theme-yellow);
+    --psp-code-editor--comment--color: var(--theme-fg2);
+    --psp-code-editor--column--color: var(--theme-green);
+
+    --psp-datagrid--pos-cell--color: var(--theme-cyan);
+    --psp-datagrid--neg-cell--color: var(--theme-orange);
+    --psp-datagrid--hover--border-color: var(--theme-line);
+
+    --psp-charts--legend--color: var(--theme-fg1);
+    --psp-charts--treemap--labels: var(--theme-fg0);
+    --psp-charts--treemap--hover-highlight: var(--theme-white);
+    --psp-charts--tooltip--color: var(--theme-fg0);
+    --psp-charts--axis-ticks--color: var(--theme-fg0);
+    --psp-charts--axis-lines--color: var(--theme-fg2);
+    --psp-charts--gridline--color: var(--theme-bg2);
+    --psp-charts--tooltip--background: var(--theme-bg1);
+    --psp-charts--tooltip--border-color: var(--theme-line);
+    --psp-charts--legend--background: var(--psp--background-color);
+
+    --psp-charts--series--color: var(--theme-cyan);
+    --psp-charts--series-1--color: var(--theme-cyan);
+    --psp-charts--series-2--color: var(--theme-yellow);
+    --psp-charts--series-3--color: var(--theme-orange);
+    --psp-charts--series-4--color: var(--theme-green);
+    --psp-charts--series-5--color: var(--theme-pink);
+    --psp-charts--series-6--color: var(--theme-white);
+    --psp-charts--series-7--color: var(--theme-lavender);
+    --psp-charts--series-8--color: var(--theme-mint);
+    --psp-charts--series-9--color: var(--theme-magenta);
+    --psp-charts--series-10--color: var(--theme-sky);
+    --psp-datagrid--series-1--color: var(--theme-cyan);
+    --psp-datagrid--series-2--color: var(--theme-yellow);
+    --psp-datagrid--series-3--color: var(--theme-orange);
+    --psp-datagrid--series-4--color: var(--theme-green);
+    --psp-datagrid--series-5--color: var(--theme-pink);
+    --psp-datagrid--series-6--color: var(--theme-white);
+    --psp-datagrid--series-7--color: var(--theme-lavender);
+    --psp-datagrid--series-8--color: var(--theme-mint);
+    --psp-datagrid--series-9--color: var(--theme-magenta);
+    --psp-datagrid--series-10--color: var(--theme-sky);
+
+    --psp-charts--gradient--background: linear-gradient(
+        var(--theme-orange) 0%,
+        var(--theme-bg0) 50%,
+        var(--theme-cyan) 100%
+    );
+
+    --psp-openlayers--tile-url: "http://{a-c}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png";
+    --psp-openlayers--attribution--filter: invert(1) hue-rotate(180deg);
+    --psp-openlayers--element--background: var(--theme-bg1);
+    --psp-openlayers--category-1--color: var(--theme-cyan);
+    --psp-openlayers--category-2--color: var(--theme-yellow);
+    --psp-openlayers--category-3--color: var(--theme-orange);
+    --psp-openlayers--category-4--color: var(--theme-green);
+    --psp-openlayers--category-5--color: var(--theme-pink);
+    --psp-openlayers--category-6--color: var(--theme-white);
+    --psp-openlayers--category-7--color: var(--theme-lavender);
+    --psp-openlayers--category-8--color: var(--theme-mint);
+    --psp-openlayers--category-9--color: var(--theme-magenta);
+    --psp-openlayers--category-10--color: var(--theme-sky);
+    --psp-openlayers--gradient--background: linear-gradient(
+        var(--theme-orange) 0%,
+        var(--theme-bg0) 50%,
+        var(--theme-cyan) 100%
+    );
+}
+
+perspective-context-menu[theme="Blueprint"],
+perspective-copy-menu[theme="Blueprint"],
+perspective-export-menu[theme="Blueprint"],
+perspective-dropdown[theme="Blueprint"],
+perspective-date-column-style[theme="Blueprint"],
+perspective-datetime-column-style[theme="Blueprint"],
+perspective-number-column-style[theme="Blueprint"],
+perspective-string-column-style[theme="Blueprint"] {
+    --theme-bg0: #0c2f6b;
+    --theme-bg1: #103a80;
+    --theme-bg2: #1b478f;
+    --theme-bg3: #2a58a8;
+    --theme-fg0: #e6f0ff;
+    --theme-fg1: #a9c4ee;
+    --theme-fg2: #5b84c6;
+    --theme-line: #3b6fc4;
+    --theme-cyan: #7fd3ff;
+    --theme-yellow: #ffd166;
+    --theme-orange: #ff8a65;
+    --theme-green: #b8e986;
+    --theme-pink: #ff9ecf;
+    --theme-white: #ffffff;
+    --theme-lavender: #c3b1ff;
+    --theme-mint: #5ee7c7;
+    --theme-magenta: #f6a6ff;
+    --theme-sky: #9cc3ff;
+
+    background-color: var(--theme-bg0);
+    color: var(--theme-fg0);
+    color-scheme: dark;
+    --psp--color: var(--theme-fg0);
+    --psp-active--color: var(--theme-cyan);
+    --psp-error--color: var(--theme-orange);
+    --psp-inactive--color: var(--theme-fg2);
+    --psp-inactive--border-color: var(--theme-bg3);
+    --psp--background-color: var(--theme-bg0);
+    --psp-active--background: rgba(127, 211, 255, 0.3);
+    --psp-expression--operator--color: var(--theme-fg1);
+    --psp-expression--function--color: var(--theme-cyan);
+    --psp-expression--psp-error--color: var(--theme-orange);
+    --psp-calendar--filter: invert(1);
+    --psp-input--filter: invert(1);
+    --psp-warning--color: var(--theme-bg0);
+    --psp-warning--background: var(--theme-yellow);
+    --psp-status-icon--connected--color: var(--theme-green);
+    --psp-status-icon--initializing--color: var(--theme-yellow);
+    --psp-status-icon--psp-error--color: var(--theme-orange);
+
+    --psp-code-editor--symbol--color: var(--theme-fg0);
+    --psp-code-editor--literal--color: var(--theme-cyan);
+    --psp-code-editor--operator--color: var(--theme-yellow);
+    --psp-code-editor--comment--color: var(--theme-fg2);
+    --psp-code-editor--column--color: var(--theme-green);
+
+    border: 1px solid #2a58a8;
+}

--- a/rust/perspective-viewer/src/themes/botanical.css
+++ b/rust/perspective-viewer/src/themes/botanical.css
@@ -8,7 +8,8 @@
  * ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
  * ┃ This file is part of the Perspective library, distributed under the terms ┃
  * ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
- * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ */
+ * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+ */
 
 @import "./defaults.css";
 
@@ -38,14 +39,6 @@ perspective-viewer [theme="Botanical"] {
     --psp-input--filter: invert(1);
     --psp-warning--color: #1a2e1a;
     --psp-warning--background: var(--psp--color);
-
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
 
     /* Syntax */
     --psp-code-editor--symbol--color: #e0ead8;
@@ -127,14 +120,6 @@ perspective-string-column-style[theme="Botanical"] {
     --psp-input--filter: invert(1);
     --psp-warning--color: #1a2e1a;
     --psp-warning--background: var(--psp--color);
-
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
 
     --psp-code-editor--symbol--color: #e0ead8;
     --psp-code-editor--literal--color: #a8d8a0;

--- a/rust/perspective-viewer/src/themes/botanical.css
+++ b/rust/perspective-viewer/src/themes/botanical.css
@@ -25,6 +25,7 @@ perspective-viewer [theme="Botanical"] {
     /* perspective-viewer-botanical--colors */
     background-color: #1a2e1a;
     color: #e0ead8;
+    color-scheme: dark;
     --psp--color: #e0ead8;
     --psp-active--color: #5a9e4b;
     --psp-error--color: #e8836a;
@@ -106,6 +107,7 @@ perspective-string-column-style[theme="Botanical"] {
     /* perspective-viewer-botanical--colors */
     background-color: #1a2e1a;
     color: #e0ead8;
+    color-scheme: dark;
     --psp--color: #e0ead8;
     --psp-active--color: #5a9e4b;
     --psp-error--color: #e8836a;

--- a/rust/perspective-viewer/src/themes/defaults.css
+++ b/rust/perspective-viewer/src/themes/defaults.css
@@ -8,25 +8,13 @@
  * ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
  * ┃ This file is part of the Perspective library, distributed under the terms ┃
  * ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
- * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ */
+ * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+ */
 
 @import "./icons.css";
 @import "./intl.css";
 
 perspective-viewer,
-/* Per-panel light-DOM descendants (the plugin + `<PanelTab>`, both carrying a
-   `theme` attribute) get the complete base too — so each panel resolves real
-   `color`/`font-family` and every `--psp-*` from its OWN theme instead of
-   inheriting the active panel's. Theme overrides refine this via the matching
-   `perspective-viewer [theme="X"]` rule.
-
-   `:where()` gives this clause ZERO specificity, so the panel's own
-   `[theme="X"]` override (specificity 0,1,1) ALWAYS wins over this default base.
-   Without it the two would tie at (0,1,1) and import order would decide — and
-   because every theme file `@import`s `defaults.css`, the base is inlined after
-   later overrides and the default would leak over the panel's theme. A
-   zero-specificity rule still beats inheritance, so the base values apply where
-   the override is silent. */
 :where(perspective-viewer [theme]),
 perspective-context-menu,
 perspective-copy-menu,
@@ -36,27 +24,6 @@ perspective-date-column-style,
 perspective-datetime-column-style,
 perspective-number-column-style,
 perspective-string-column-style {
-    /* Colors */
-    --psp--color: #161616;
-
-    color: var(--psp--color);
-
-    --psp-inactive--color: #ababab;
-    --psp-inactive--border-color: #dadada;
-    --psp-active--color: #2670a9;
-    --psp-error--color: #ff471e;
-    --psp--background-color: #ffffff;
-    --psp-icon-overflow-hint--color: rgba(0, 0, 0, 0.2);
-    --psp-select--background-color: none;
-    --psp-warning--background: #042121;
-    --psp-warning--color: #fdfffd;
-
-    /* TODO deprecate me */
-    --psp-icon-overflow-hint--color: #fdfffd;
-    /* Colors */
-    --psp-placeholder--background: #8b868045;
-
-    /* Dimensions */
     --psp-button--font-size: 16px;
     --psp-config-button--padding: 15px 8px 6px 8px;
     --psp-column-selector--font-size: 16px;
@@ -65,7 +32,6 @@ perspective-string-column-style {
     --psp-top-panel-row--display: inline-flex;
     --psp-button--min-width: 33px;
 
-    /* Fonts */
     font-family:
         "ui-monospace", "SFMono-Regular", "SF Mono", "Menlo", "Consolas",
         "Liberation Mono", monospace;
@@ -73,92 +39,9 @@ perspective-string-column-style {
         "ui-monospace", "SFMono-Regular", "SF Mono", "Menlo", "Consolas",
         "Liberation Mono", monospace;
 
-    /* Colors (select arrow defaults) */
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-
-    /* webgl */
     --psp-label--webgl-y1--content: "arrow_upward";
     --psp-label--webgl-y2--content: "arrow_downward";
-    --psp-charts--treemap-axis--lines: none;
-    --psp-charts--tooltip--background-color: rgba(155, 155, 155, 0.8);
-    --psp-charts--tooltip--color: #161616;
-    --psp-charts--tooltip--border-color: #fff;
-    --psp-charts--tooltip--box-shadow: 0 2px 4px 0 rgb(0 0 0 / 10%);
-    --psp-charts--gridline--color: #eaedef;
-    --psp-charts--axis-ticks--color: #161616;
-    --psp-charts--axis-lines--color: #c5c9d0;
-    --psp-charts--legend--background: var(--psp--background-color);
-    --psp-charts--series--color: rgba(31, 119, 180, 0.8);
-    --psp-charts--series-1--color: #0366d6;
-    --psp-charts--series-2--color: #ff7f0e;
-    --psp-charts--series-3--color: #2ca02c;
-    --psp-charts--series-4--color: #d62728;
-    --psp-charts--series-5--color: #9467bd;
-    --psp-charts--series-6--color: #8c564b;
-    --psp-charts--series-7--color: #e377c2;
-    --psp-charts--series-8--color: #7f7f7f;
-    --psp-charts--series-9--color: #bcbd22;
-    --psp-charts--series-10--color: #17becf;
-    --psp-datagrid--series-1--color: #0366d6;
-    --psp-datagrid--series-2--color: #ff7f0e;
-    --psp-datagrid--series-3--color: #2ca02c;
-    --psp-datagrid--series-4--color: #d62728;
-    --psp-datagrid--series-5--color: #9467bd;
-    --psp-datagrid--series-6--color: #8c564b;
-    --psp-datagrid--series-7--color: #e377c2;
-    --psp-datagrid--series-8--color: #7f7f7f;
-    --psp-datagrid--series-9--color: #bcbd22;
-    --psp-datagrid--series-10--color: #17becf;
-    --psp-charts--gradient--background: linear-gradient(
-        #4d342f 0%,
-        #e4521b 22.5%,
-        #feeb65 42.5%,
-        #f0f0f0 50%,
-        #dcedc8 57.5%,
-        #42b3d5 67.5%,
-        #1a237e 100%
-    );
 
-    /* Datagrid */
-    --psp-datagrid--pos-cell--color: #338dcd;
-    --psp-datagrid--neg-cell--color: #ff471e;
-
-    /* OpenLayers */
-    --psp-openlayers--tile-url: "http://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png";
-    --psp-openlayers--element--background: #fff;
-    --psp-openlayers--category-1--color: #0366d6;
-    --psp-openlayers--category-2--color: #ff7f0e;
-    --psp-openlayers--category-3--color: #2ca02c;
-    --psp-openlayers--category-4--color: #d62728;
-    --psp-openlayers--category-5--color: #9467bd;
-    --psp-openlayers--category-6--color: #8c564b;
-    --psp-openlayers--category-7--color: #e377c2;
-    --psp-openlayers--category-8--color: #7f7f7f;
-    --psp-openlayers--category-9--color: #bcbd22;
-    --psp-openlayers--category-10--color: #17becf;
-    --psp-openlayers--gradient--background: linear-gradient(
-        #4d342f 0%,
-        #e4521b 22.5%,
-        #feeb65 42.5%,
-        #f0f0f0 50%,
-        #dcedc8 57.5%,
-        #42b3d5 67.5%,
-        #1a237e 100%
-    );
-
-    /* Completeness anchors for per-panel theming. These are color/appearance
-       vars that some themes (e.g. Pro Dark) set but the light default does not
-       — so without a base value an unthemed/light panel would *inherit* them
-       from a differently-themed (active) panel, mixing themes. `initial` makes
-       the custom property the guaranteed-invalid value: consumers fall back to
-       their own default (identical to the current unthemed rendering) AND the
-       element no longer inherits a neighboring panel's value. A theme that
-       wants a real value overrides it in its `[theme="X"]` block as usual. */
     --psp-active--background: initial;
     --psp-calendar--filter: initial;
     --psp-charts--legend--color: initial;
@@ -192,7 +75,6 @@ perspective-string-column-style {
     --psp-status-icon--psp-error--color: initial;
 }
 
-/* Modal defaults */
 perspective-context-menu,
 perspective-copy-menu,
 perspective-export-menu,

--- a/rust/perspective-viewer/src/themes/dracula.css
+++ b/rust/perspective-viewer/src/themes/dracula.css
@@ -23,6 +23,7 @@ perspective-viewer [theme="Dracula"] {
     /* perspective-viewer-pro-dark--colors (overrides) */
     background-color: #242526;
     color: white;
+    color-scheme: dark;
     --psp--color: white;
     --psp-active--color: #2770a9;
     --psp-error--color: #ff9485;
@@ -172,6 +173,7 @@ perspective-dropdown[theme="Dracula"] {
     /* perspective-viewer-pro-dark--colors (overrides) */
     background-color: #242526;
     color: white;
+    color-scheme: dark;
     --psp--color: white;
     --psp-active--color: #2770a9;
     --psp-error--color: #ff9485;

--- a/rust/perspective-viewer/src/themes/dracula.css
+++ b/rust/perspective-viewer/src/themes/dracula.css
@@ -38,14 +38,6 @@ perspective-viewer [theme="Dracula"] {
     --psp-warning--color: #242526;
     --psp-warning--background: var(--psp--color);
 
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
-
     --psp-code-editor--symbol--color: white;
     --psp-code-editor--literal--color: #7dc3f0;
     --psp-code-editor--operator--color: rgb(23, 166, 123);
@@ -194,12 +186,6 @@ perspective-dropdown[theme="Dracula"] {
     --psp-input--filter: invert(1);
     --psp-warning--color: #242526;
     --psp-warning--background: var(--psp--color);
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
     --psp-code-editor--symbol--color: white;
     --psp-code-editor--literal--color: #7dc3f0;
     --psp-code-editor--operator--color: rgb(23, 166, 123);

--- a/rust/perspective-viewer/src/themes/eggplant.css
+++ b/rust/perspective-viewer/src/themes/eggplant.css
@@ -1,0 +1,189 @@
+/* ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+ * ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+ * ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+ * ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+ * ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+ * ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+ * ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+ * ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+ * ┃ This file is part of the Perspective library, distributed under the terms ┃
+ * ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+ * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+ */
+
+@import "./defaults.css";
+
+perspective-viewer,
+perspective-viewer[theme="Eggplant"],
+perspective-viewer [theme="Eggplant"] {
+    --psp-theme-name: "Eggplant";
+}
+
+perspective-viewer[theme="Eggplant"],
+perspective-viewer [theme="Eggplant"] {
+    --theme-bg0: #1e1230;
+    --theme-bg1: #2a1a42;
+    --theme-bg2: #3a2758;
+    --theme-bg3: #4d3670;
+    --theme-fg0: #f1eaff;
+    --theme-fg1: #cbbde8;
+    --theme-fg2: #7d6a9e;
+    --theme-green: #7ee787;
+    --theme-yellow: #ffd75e;
+    --theme-lime: #c8f060;
+    --theme-mint: #6ee7c8;
+    --theme-amber: #f0b86e;
+    --theme-lavender: #b8a1ff;
+    --theme-sky: #9be3ff;
+    --theme-rose: #ff7b8a;
+    --theme-pink: #ff8fd6;
+    --theme-coral: #ff8a80;
+    --theme-periwinkle: #7fa8ff;
+
+    background-color: var(--theme-bg0);
+    color: var(--theme-fg0);
+    color-scheme: dark;
+    --psp--color: var(--theme-fg1);
+    --psp-active--color: var(--theme-green);
+    --psp-error--color: var(--theme-rose);
+    --psp-inactive--color: var(--theme-fg2);
+    --psp-inactive--border-color: var(--theme-bg3);
+    --psp--background-color: var(--theme-bg0);
+    --psp-active--background: rgba(126, 231, 135, 0.3);
+    --psp-expression--operator--color: var(--theme-yellow);
+    --psp-expression--function--color: var(--theme-green);
+    --psp-expression--psp-error--color: var(--theme-rose);
+    --psp-calendar--filter: invert(1);
+    --psp-input--filter: invert(1);
+    --psp-warning--color: var(--theme-bg0);
+    --psp-warning--background: var(--theme-yellow);
+
+    --psp-status-icon--connected--color: var(--theme-green);
+    --psp-status-icon--initializing--color: var(--theme-yellow);
+    --psp-status-icon--psp-error--color: var(--theme-rose);
+
+    --psp-code-editor--symbol--color: var(--theme-fg0);
+    --psp-code-editor--literal--color: var(--theme-yellow);
+    --psp-code-editor--operator--color: var(--theme-yellow);
+    --psp-code-editor--comment--color: var(--theme-fg2);
+    --psp-code-editor--column--color: var(--theme-lime);
+
+    --psp-datagrid--pos-cell--color: var(--theme-green);
+    --psp-datagrid--neg-cell--color: var(--theme-yellow);
+
+    --psp-charts--legend--color: var(--theme-fg1);
+    --psp-charts--treemap--labels: var(--theme-fg0);
+    --psp-charts--treemap--hover-highlight: var(--theme-fg0);
+    --psp-charts--tooltip--color: var(--theme-fg0);
+    --psp-charts--axis-ticks--color: var(--theme-fg1);
+    --psp-charts--axis-lines--color: var(--theme-bg3);
+    --psp-charts--gridline--color: var(--theme-bg2);
+    --psp-charts--tooltip--background: var(--theme-bg1);
+    --psp-charts--tooltip--border-color: var(--theme-bg3);
+    --psp-charts--legend--background: var(--psp--background-color);
+
+    --psp-charts--series--color: var(--theme-green);
+    --psp-charts--series-1--color: var(--theme-green);
+    --psp-charts--series-2--color: var(--theme-yellow);
+    --psp-charts--series-3--color: var(--theme-sky);
+    --psp-charts--series-4--color: var(--theme-pink);
+    --psp-charts--series-5--color: var(--theme-amber);
+    --psp-charts--series-6--color: var(--theme-lavender);
+    --psp-charts--series-7--color: var(--theme-mint);
+    --psp-charts--series-8--color: var(--theme-coral);
+    --psp-charts--series-9--color: var(--theme-lime);
+    --psp-charts--series-10--color: var(--theme-periwinkle);
+    --psp-datagrid--series-1--color: var(--theme-green);
+    --psp-datagrid--series-2--color: var(--theme-yellow);
+    --psp-datagrid--series-3--color: var(--theme-sky);
+    --psp-datagrid--series-4--color: var(--theme-pink);
+    --psp-datagrid--series-5--color: var(--theme-amber);
+    --psp-datagrid--series-6--color: var(--theme-lavender);
+    --psp-datagrid--series-7--color: var(--theme-mint);
+    --psp-datagrid--series-8--color: var(--theme-coral);
+    --psp-datagrid--series-9--color: var(--theme-lime);
+    --psp-datagrid--series-10--color: var(--theme-periwinkle);
+
+    --psp-charts--gradient--background: linear-gradient(
+        var(--theme-yellow) 0%,
+        var(--theme-bg0) 50%,
+        var(--theme-green) 100%
+    );
+
+    --psp-openlayers--tile-url: "http://{a-c}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png";
+    --psp-openlayers--attribution--filter: invert(1) hue-rotate(180deg);
+    --psp-openlayers--element--background: var(--theme-bg1);
+    --psp-openlayers--category-1--color: var(--theme-green);
+    --psp-openlayers--category-2--color: var(--theme-yellow);
+    --psp-openlayers--category-3--color: var(--theme-sky);
+    --psp-openlayers--category-4--color: var(--theme-pink);
+    --psp-openlayers--category-5--color: var(--theme-amber);
+    --psp-openlayers--category-6--color: var(--theme-lavender);
+    --psp-openlayers--category-7--color: var(--theme-mint);
+    --psp-openlayers--category-8--color: var(--theme-coral);
+    --psp-openlayers--category-9--color: var(--theme-lime);
+    --psp-openlayers--category-10--color: var(--theme-periwinkle);
+    --psp-openlayers--gradient--background: linear-gradient(
+        var(--theme-yellow) 0%,
+        var(--theme-bg0) 50%,
+        var(--theme-green) 100%
+    );
+}
+
+perspective-context-menu[theme="Eggplant"],
+perspective-copy-menu[theme="Eggplant"],
+perspective-export-menu[theme="Eggplant"],
+perspective-dropdown[theme="Eggplant"],
+perspective-date-column-style[theme="Eggplant"],
+perspective-datetime-column-style[theme="Eggplant"],
+perspective-number-column-style[theme="Eggplant"],
+perspective-string-column-style[theme="Eggplant"] {
+    --theme-bg0: #1e1230;
+    --theme-bg1: #2a1a42;
+    --theme-bg2: #3a2758;
+    --theme-bg3: #4d3670;
+    --theme-fg0: #f1eaff;
+    --theme-fg1: #cbbde8;
+    --theme-fg2: #7d6a9e;
+    --theme-green: #7ee787;
+    --theme-yellow: #ffd75e;
+    --theme-lime: #c8f060;
+    --theme-mint: #6ee7c8;
+    --theme-amber: #f0b86e;
+    --theme-lavender: #b8a1ff;
+    --theme-sky: #9be3ff;
+    --theme-rose: #ff7b8a;
+    --theme-pink: #ff8fd6;
+    --theme-coral: #ff8a80;
+    --theme-periwinkle: #7fa8ff;
+
+    background-color: var(--theme-bg0);
+    color: var(--theme-fg0);
+    color-scheme: dark;
+    --psp--color: var(--theme-fg1);
+    --psp-active--color: var(--theme-green);
+    --psp-error--color: var(--theme-rose);
+    --psp-inactive--color: var(--theme-fg2);
+    --psp-inactive--border-color: var(--theme-bg3);
+    --psp--background-color: var(--theme-bg0);
+    --psp-active--background: rgba(126, 231, 135, 0.3);
+    --psp-expression--operator--color: var(--theme-yellow);
+    --psp-expression--function--color: var(--theme-green);
+    --psp-expression--psp-error--color: var(--theme-rose);
+    --psp-calendar--filter: invert(1);
+    --psp-input--filter: invert(1);
+    --psp-warning--color: var(--theme-bg0);
+    --psp-warning--background: var(--theme-yellow);
+
+    --psp-status-icon--connected--color: var(--theme-green);
+    --psp-status-icon--initializing--color: var(--theme-yellow);
+    --psp-status-icon--psp-error--color: var(--theme-rose);
+
+    --psp-code-editor--symbol--color: var(--theme-fg0);
+    --psp-code-editor--literal--color: var(--theme-yellow);
+    --psp-code-editor--operator--color: var(--theme-yellow);
+    --psp-code-editor--comment--color: var(--theme-fg2);
+    --psp-code-editor--column--color: var(--theme-lime);
+
+    border: 1px solid #4d3670;
+}

--- a/rust/perspective-viewer/src/themes/gruvbox-dark.css
+++ b/rust/perspective-viewer/src/themes/gruvbox-dark.css
@@ -38,14 +38,6 @@ perspective-viewer [theme="Gruvbox Dark"] {
     --psp-warning--color: #242526;
     --psp-warning--background: var(--psp--color);
 
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
-
     --psp-code-editor--symbol--color: white;
     --psp-code-editor--literal--color: #7dc3f0;
     --psp-code-editor--operator--color: rgb(23, 166, 123);
@@ -210,12 +202,6 @@ perspective-dropdown[theme="Gruvbox Dark"] {
     --psp-input--filter: invert(1);
     --psp-warning--color: #242526;
     --psp-warning--background: var(--psp--color);
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
     --psp-code-editor--symbol--color: white;
     --psp-code-editor--literal--color: #7dc3f0;
     --psp-code-editor--operator--color: rgb(23, 166, 123);

--- a/rust/perspective-viewer/src/themes/gruvbox-dark.css
+++ b/rust/perspective-viewer/src/themes/gruvbox-dark.css
@@ -23,6 +23,7 @@ perspective-viewer [theme="Gruvbox Dark"] {
     /* perspective-viewer-pro-dark--colors (overrides) */
     background-color: #242526;
     color: white;
+    color-scheme: dark;
     --psp--color: white;
     --psp-active--color: #2770a9;
     --psp-error--color: #ff9485;
@@ -188,6 +189,7 @@ perspective-dropdown[theme="Gruvbox Dark"] {
     /* perspective-viewer-pro-dark--colors (overrides) */
     background-color: #242526;
     color: white;
+    color-scheme: dark;
     --psp--color: white;
     --psp-active--color: #2770a9;
     --psp-error--color: #ff9485;

--- a/rust/perspective-viewer/src/themes/gruvbox-dark.css
+++ b/rust/perspective-viewer/src/themes/gruvbox-dark.css
@@ -150,7 +150,7 @@ perspective-viewer [theme="Gruvbox Dark"] {
 
     /* perspective-viewer-gruvbox-dark--webgl */
     --psp-charts--axis-ticks--color: var(--theme-fg1);
-    --psp-charts--gridline--color: var(--theme-bg2);
+    --psp-charts--gridline--color: var(--theme-bg1);
     --psp-charts--series--color: var(--theme-blue);
     --psp-charts--series-1--color: var(--theme-blue);
     --psp-charts--series-2--color: var(--theme-red);

--- a/rust/perspective-viewer/src/themes/gruvbox.css
+++ b/rust/perspective-viewer/src/themes/gruvbox.css
@@ -63,7 +63,7 @@ perspective-viewer [theme="Gruvbox Light"] {
 
     /* perspective-viewer-gruvbox-light--webgl */
     --psp-charts--axis-ticks--color: var(--theme-fg1);
-    --psp-charts--gridline--color: var(--theme-bg2);
+    --psp-charts--gridline--color: var(--theme-bg1);
     --psp-charts--series--color: var(--theme-blue);
     --psp-charts--series-1--color: var(--theme-blue);
     --psp-charts--series-2--color: var(--theme-red);

--- a/rust/perspective-viewer/src/themes/icons.css
+++ b/rust/perspective-viewer/src/themes/icons.css
@@ -55,8 +55,7 @@ perspective-viewer-tab {
     --psp-icon--pin--mask-image: url("../svg/pin-icon.svg");
     --psp-label--inactive-column-selector--content: url("../svg/checkbox-unchecked-icon.svg");
     --psp-label--active-column-selector--content: url("../svg/checkbox-checked-icon.svg");
-    --psp-icon--select-arrow-light--mask-image: url("../svg/dropdown-selector-light.svg");
-    --psp-icon--select-arrow-dark--mask-image: url("../svg/dropdown-selector.svg");
+    --psp-icon--select-arrow--mask-image: url("../svg/dropdown-selector.svg");
     --psp-icon--active-indicator--mask-image: url("../svg/active-indicator.svg");
     --psp-icon-overflow-hint--content: "!";
     --psp-label--reset-button-icon--content: "refresh";

--- a/rust/perspective-viewer/src/themes/intl.css
+++ b/rust/perspective-viewer/src/themes/intl.css
@@ -108,9 +108,9 @@ perspective-dropdown {
     --psp-label--group-basemap--content: "Basemap";
     --psp-label--group-legend--content: "Legend";
     --psp-label--group-tooltip--content: "Tooltips";
-    --psp-label--group-fg--content: "Foreground";
-    --psp-label--group-bg--content: "Background";
+    --psp-label--group-color--content: "Color";
     --psp-label--group-format--content: "Format";
+    --psp-label--column-size-override--content: "Column Width";
 
     /* Tabs */
     --psp-label--style-tab--content: "Style";

--- a/rust/perspective-viewer/src/themes/intl.css
+++ b/rust/perspective-viewer/src/themes/intl.css
@@ -101,6 +101,17 @@ perspective-dropdown {
     --psp-label--fractional-seconds--content: "Fractional Seconds";
     --psp-label--hours--content: "12/24 Hours";
 
+    --psp-label--group-axes--content: "Axes";
+    --psp-label--group-facets--content: "Facets";
+    --psp-label--group-glyph--content: "Glyphs";
+    --psp-label--group-density--content: "Density";
+    --psp-label--group-basemap--content: "Basemap";
+    --psp-label--group-legend--content: "Legend";
+    --psp-label--group-tooltip--content: "Tooltips";
+    --psp-label--group-fg--content: "Foreground";
+    --psp-label--group-bg--content: "Background";
+    --psp-label--group-format--content: "Format";
+
     /* Tabs */
     --psp-label--style-tab--content: "Style";
     --psp-label--attributes-tab--content: "Expression";
@@ -139,10 +150,10 @@ perspective-dropdown {
     --psp-label--chart-type--content: "Glyph type";
 
     /* Plugin settings — viewer-charts */
-    --psp-label--auto-alt-y-axis--content: "Auto dual Y axis";
-    --psp-label--facet-mode--content: "Facet mode";
-    --psp-label--facet-zoom-mode--content: "Facet zoom";
-    --psp-label--series-zoom-mode--content: "Series zoom";
+    --psp-label--auto-alt-y-axis--content: "Auto Y axis";
+    --psp-label--facet-mode--content: "Split mode";
+    --psp-label--facet-zoom-mode--content: "Zoom mode";
+    --psp-label--series-zoom-mode--content: "Series zoom mode";
     --psp-label--line-width-px--content: "Line width";
     --psp-label--point-size-px--content: "Point size";
     --psp-label--band-inner-frac--content: "Band width";
@@ -159,12 +170,14 @@ perspective-dropdown {
     --psp-label--map-tile-alpha--content: "Map opacity";
     --psp-label--numeric-axes--content: "Numeric axes";
     --psp-label--interpolate--content: "Interpolate null";
-    --psp-label--legend-mode--content: "Legend mode";
-    --psp-label--legend-size-mode--content: "Legend sizing";
-    --psp-label--legend-width-px--content: "Legend width";
-    --psp-label--legend-height-px--content: "Legend height";
-    --psp-label--legend-anchor--content: "Legend anchor";
-    --psp-label--legend-x--content: "Legend X offset";
-    --psp-label--legend-y--content: "Legend Y offset";
-    --psp-label--legend-opacity--content: "Legend opacity";
+    --psp-label--legend-mode--content: "Placement mode";
+    --psp-label--legend-size-mode--content: "Sizing mode";
+    --psp-label--legend-width-px--content: "Width";
+    --psp-label--legend-height-px--content: "Height";
+    --psp-label--legend-anchor--content: "Anchor";
+    --psp-label--legend-x--content: "X offset";
+    --psp-label--legend-y--content: "Y offset";
+    --psp-label--legend-opacity--content: "Opacity";
+    --psp-label--tooltip-max-column-px--content: "Max column width";
+    --psp-label--tooltip-opacity--content: "Opacity";
 }

--- a/rust/perspective-viewer/src/themes/intl/de.css
+++ b/rust/perspective-viewer/src/themes/intl/de.css
@@ -178,7 +178,7 @@ perspective-dropdown {
     --psp-label--group-basemap--content: "Basiskarte";
     --psp-label--group-legend--content: "Legende";
     --psp-label--group-tooltip--content: "Tooltips";
-    --psp-label--group-fg--content: "Vordergrund";
-    --psp-label--group-bg--content: "Hintergrund";
+    --psp-label--group-color--content: "Farbe";
     --psp-label--group-format--content: "Format";
+    --psp-label--column-size-override--content: "Spaltenbreite";
 }

--- a/rust/perspective-viewer/src/themes/intl/de.css
+++ b/rust/perspective-viewer/src/themes/intl/de.css
@@ -168,4 +168,17 @@ perspective-dropdown {
     --psp-label--legend-x--content: "Legenden-X-Versatz";
     --psp-label--legend-y--content: "Legenden-Y-Versatz";
     --psp-label--legend-opacity--content: "Legendentransparenz";
+    --psp-label--tooltip-max-column-px--content: "Maximale Spaltenbreite";
+    --psp-label--tooltip-opacity--content: "Deckkraft";
+
+    --psp-label--group-axes--content: "Achsen";
+    --psp-label--group-facets--content: "Facetten";
+    --psp-label--group-glyph--content: "Glyphen";
+    --psp-label--group-density--content: "Dichte";
+    --psp-label--group-basemap--content: "Basiskarte";
+    --psp-label--group-legend--content: "Legende";
+    --psp-label--group-tooltip--content: "Tooltips";
+    --psp-label--group-fg--content: "Vordergrund";
+    --psp-label--group-bg--content: "Hintergrund";
+    --psp-label--group-format--content: "Format";
 }

--- a/rust/perspective-viewer/src/themes/intl/es.css
+++ b/rust/perspective-viewer/src/themes/intl/es.css
@@ -178,7 +178,7 @@ perspective-dropdown {
     --psp-label--group-basemap--content: "Mapa base";
     --psp-label--group-legend--content: "Leyenda";
     --psp-label--group-tooltip--content: "Descripciones";
-    --psp-label--group-fg--content: "Primer plano";
-    --psp-label--group-bg--content: "Fondo";
+    --psp-label--group-color--content: "Color";
     --psp-label--group-format--content: "Formato";
+    --psp-label--column-size-override--content: "Ancho de columna";
 }

--- a/rust/perspective-viewer/src/themes/intl/es.css
+++ b/rust/perspective-viewer/src/themes/intl/es.css
@@ -168,4 +168,17 @@ perspective-dropdown {
     --psp-label--legend-x--content: "Desplazamiento X de leyenda";
     --psp-label--legend-y--content: "Desplazamiento Y de leyenda";
     --psp-label--legend-opacity--content: "Opacidad de leyenda";
+    --psp-label--tooltip-max-column-px--content: "Ancho máximo de columna";
+    --psp-label--tooltip-opacity--content: "Opacidad";
+
+    --psp-label--group-axes--content: "Ejes";
+    --psp-label--group-facets--content: "Facetas";
+    --psp-label--group-glyph--content: "Glifos";
+    --psp-label--group-density--content: "Densidad";
+    --psp-label--group-basemap--content: "Mapa base";
+    --psp-label--group-legend--content: "Leyenda";
+    --psp-label--group-tooltip--content: "Descripciones";
+    --psp-label--group-fg--content: "Primer plano";
+    --psp-label--group-bg--content: "Fondo";
+    --psp-label--group-format--content: "Formato";
 }

--- a/rust/perspective-viewer/src/themes/intl/fr.css
+++ b/rust/perspective-viewer/src/themes/intl/fr.css
@@ -168,4 +168,17 @@ perspective-dropdown {
     --psp-label--legend-x--content: "Décalage X légende";
     --psp-label--legend-y--content: "Décalage Y légende";
     --psp-label--legend-opacity--content: "Opacité de légende";
+    --psp-label--tooltip-max-column-px--content: "Largeur max. de colonne";
+    --psp-label--tooltip-opacity--content: "Opacité";
+
+    --psp-label--group-axes--content: "Axes";
+    --psp-label--group-facets--content: "Facettes";
+    --psp-label--group-glyph--content: "Glyphes";
+    --psp-label--group-density--content: "Densité";
+    --psp-label--group-basemap--content: "Fond de carte";
+    --psp-label--group-legend--content: "Légende";
+    --psp-label--group-tooltip--content: "Info-bulles";
+    --psp-label--group-fg--content: "Premier plan";
+    --psp-label--group-bg--content: "Arrière-plan";
+    --psp-label--group-format--content: "Format";
 }

--- a/rust/perspective-viewer/src/themes/intl/fr.css
+++ b/rust/perspective-viewer/src/themes/intl/fr.css
@@ -178,7 +178,7 @@ perspective-dropdown {
     --psp-label--group-basemap--content: "Fond de carte";
     --psp-label--group-legend--content: "Légende";
     --psp-label--group-tooltip--content: "Info-bulles";
-    --psp-label--group-fg--content: "Premier plan";
-    --psp-label--group-bg--content: "Arrière-plan";
+    --psp-label--group-color--content: "Couleur";
     --psp-label--group-format--content: "Format";
+    --psp-label--column-size-override--content: "Largeur de colonne";
 }

--- a/rust/perspective-viewer/src/themes/intl/ja.css
+++ b/rust/perspective-viewer/src/themes/intl/ja.css
@@ -178,7 +178,7 @@ perspective-dropdown {
     --psp-label--group-basemap--content: "ベースマップ";
     --psp-label--group-legend--content: "凡例";
     --psp-label--group-tooltip--content: "ツールチップ";
-    --psp-label--group-fg--content: "前景";
-    --psp-label--group-bg--content: "背景";
+    --psp-label--group-color--content: "色";
     --psp-label--group-format--content: "書式";
+    --psp-label--column-size-override--content: "列の幅";
 }

--- a/rust/perspective-viewer/src/themes/intl/ja.css
+++ b/rust/perspective-viewer/src/themes/intl/ja.css
@@ -168,4 +168,17 @@ perspective-dropdown {
     --psp-label--legend-x--content: "凡例Xオフセット";
     --psp-label--legend-y--content: "凡例Yオフセット";
     --psp-label--legend-opacity--content: "凡例の不透明度";
+    --psp-label--tooltip-max-column-px--content: "最大列幅";
+    --psp-label--tooltip-opacity--content: "不透明度";
+
+    --psp-label--group-axes--content: "軸";
+    --psp-label--group-facets--content: "ファセット";
+    --psp-label--group-glyph--content: "グリフ";
+    --psp-label--group-density--content: "密度";
+    --psp-label--group-basemap--content: "ベースマップ";
+    --psp-label--group-legend--content: "凡例";
+    --psp-label--group-tooltip--content: "ツールチップ";
+    --psp-label--group-fg--content: "前景";
+    --psp-label--group-bg--content: "背景";
+    --psp-label--group-format--content: "書式";
 }

--- a/rust/perspective-viewer/src/themes/intl/pt.css
+++ b/rust/perspective-viewer/src/themes/intl/pt.css
@@ -168,4 +168,17 @@ perspective-dropdown {
     --psp-label--legend-x--content: "Deslocamento X da legenda";
     --psp-label--legend-y--content: "Deslocamento Y da legenda";
     --psp-label--legend-opacity--content: "Opacidade da legenda";
+    --psp-label--tooltip-max-column-px--content: "Largura máxima da coluna";
+    --psp-label--tooltip-opacity--content: "Opacidade";
+
+    --psp-label--group-axes--content: "Eixos";
+    --psp-label--group-facets--content: "Facetas";
+    --psp-label--group-glyph--content: "Glifos";
+    --psp-label--group-density--content: "Densidade";
+    --psp-label--group-basemap--content: "Mapa base";
+    --psp-label--group-legend--content: "Legenda";
+    --psp-label--group-tooltip--content: "Dicas";
+    --psp-label--group-fg--content: "Primeiro plano";
+    --psp-label--group-bg--content: "Fundo";
+    --psp-label--group-format--content: "Formato";
 }

--- a/rust/perspective-viewer/src/themes/intl/pt.css
+++ b/rust/perspective-viewer/src/themes/intl/pt.css
@@ -178,7 +178,7 @@ perspective-dropdown {
     --psp-label--group-basemap--content: "Mapa base";
     --psp-label--group-legend--content: "Legenda";
     --psp-label--group-tooltip--content: "Dicas";
-    --psp-label--group-fg--content: "Primeiro plano";
-    --psp-label--group-bg--content: "Fundo";
+    --psp-label--group-color--content: "Cor";
     --psp-label--group-format--content: "Formato";
+    --psp-label--column-size-override--content: "Largura da coluna";
 }

--- a/rust/perspective-viewer/src/themes/intl/zh.css
+++ b/rust/perspective-viewer/src/themes/intl/zh.css
@@ -168,4 +168,17 @@ perspective-dropdown {
     --psp-label--legend-x--content: "图例X偏移";
     --psp-label--legend-y--content: "图例Y偏移";
     --psp-label--legend-opacity--content: "图例不透明度";
+    --psp-label--tooltip-max-column-px--content: "最大列宽";
+    --psp-label--tooltip-opacity--content: "不透明度";
+
+    --psp-label--group-axes--content: "坐标轴";
+    --psp-label--group-facets--content: "分面";
+    --psp-label--group-glyph--content: "图元";
+    --psp-label--group-density--content: "密度";
+    --psp-label--group-basemap--content: "底图";
+    --psp-label--group-legend--content: "图例";
+    --psp-label--group-tooltip--content: "工具提示";
+    --psp-label--group-fg--content: "前景";
+    --psp-label--group-bg--content: "背景";
+    --psp-label--group-format--content: "格式";
 }

--- a/rust/perspective-viewer/src/themes/intl/zh.css
+++ b/rust/perspective-viewer/src/themes/intl/zh.css
@@ -178,7 +178,7 @@ perspective-dropdown {
     --psp-label--group-basemap--content: "底图";
     --psp-label--group-legend--content: "图例";
     --psp-label--group-tooltip--content: "工具提示";
-    --psp-label--group-fg--content: "前景";
-    --psp-label--group-bg--content: "背景";
+    --psp-label--group-color--content: "颜色";
     --psp-label--group-format--content: "格式";
+    --psp-label--column-size-override--content: "列宽";
 }

--- a/rust/perspective-viewer/src/themes/ledger.css
+++ b/rust/perspective-viewer/src/themes/ledger.css
@@ -1,0 +1,195 @@
+/* ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+ * ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+ * ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+ * ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+ * ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+ * ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+ * ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+ * ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+ * ┃ This file is part of the Perspective library, distributed under the terms ┃
+ * ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+ * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ */
+
+@import "./defaults.css";
+
+perspective-viewer,
+perspective-viewer[theme="Ledger"],
+perspective-viewer [theme="Ledger"] {
+    --psp-theme-name: "Ledger";
+}
+
+perspective-viewer[theme="Ledger"],
+perspective-viewer [theme="Ledger"] {
+    --theme-paper-0: #fbf7ec;
+    --theme-paper-1: #f4eedd;
+    --theme-paper-2: #e6ddc4;
+    --theme-rule-0: #dfe7d9;
+    --theme-rule-1: #b9cbb3;
+
+    --theme-ink-0: #2b2a26;
+    --theme-ink-1: #5d574b;
+    --theme-ink-2: #a29c8e;
+
+    --theme-blue: #1f4e8c;
+    --theme-red: #b3261e;
+    --theme-green: #2e6b3a;
+    --theme-ochre: #b7791f;
+    --theme-violet: #5b3a8c;
+    --theme-sepia: #8a5a2b;
+    --theme-teal: #1d7a7a;
+    --theme-magenta: #a03a6a;
+    --theme-olive: #4a6b1f;
+
+    background-color: var(--theme-paper-1);
+    color: var(--theme-ink-0);
+    --psp--color: var(--theme-ink-0);
+    --psp-active--color: var(--theme-blue);
+    --psp-error--color: var(--theme-red);
+    --psp-inactive--color: var(--theme-ink-2);
+    --psp-inactive--border-color: var(--theme-paper-2);
+    --psp--background-color: var(--theme-paper-0);
+    --psp-active--background: rgba(31, 78, 140, 0.15);
+    --psp-expression--operator--color: var(--theme-ink-1);
+    --psp-expression--function--color: var(--theme-blue);
+    --psp-expression--psp-error--color: var(--theme-red);
+    --psp-warning--color: var(--theme-paper-0);
+    --psp-warning--background: var(--theme-ink-0);
+    --psp-icon-overflow-hint--color: rgba(43, 42, 38, 0.2);
+    --psp-placeholder--background: rgba(162, 156, 142, 0.3);
+
+    --psp-status-icon--connected--color: var(--theme-green);
+    --psp-status-icon--initializing--color: var(--theme-ochre);
+    --psp-status-icon--psp-error--color: var(--theme-red);
+
+    --psp-column-type--float--color: var(--theme-blue);
+    --psp-column-type--string--color: var(--theme-red);
+    --psp-column-type--date--color: var(--theme-teal);
+    --psp-column-type--boolean--color: var(--theme-ochre);
+
+    --psp-code-editor--symbol--color: var(--theme-ink-0);
+    --psp-code-editor--literal--color: var(--theme-blue);
+    --psp-code-editor--operator--color: var(--theme-sepia);
+    --psp-code-editor--comment--color: var(--theme-ink-2);
+    --psp-code-editor--column--color: var(--theme-violet);
+
+    --psp-datagrid--pos-cell--color: var(--theme-green);
+    --psp-datagrid--neg-cell--color: var(--theme-red);
+    --psp-datagrid--hover--border-color: var(--theme-rule-1);
+    --psp-datagrid--border-color: var(--theme-rule-1);
+
+    --psp-charts--legend--color: var(--theme-ink-1);
+    --psp-charts--treemap--labels: var(--theme-ink-0);
+    --psp-charts--treemap--hover-highlight: var(--theme-ink-0);
+    --psp-charts--tooltip--color: var(--theme-ink-0);
+    --psp-charts--axis-ticks--color: var(--theme-ink-0);
+    --psp-charts--axis-lines--color: var(--theme-rule-1);
+    --psp-charts--gridline--color: var(--theme-rule-0);
+    --psp-charts--tooltip--background: var(--theme-paper-0);
+    --psp-charts--tooltip--border-color: var(--theme-paper-2);
+    --psp-charts--legend--background: var(--psp--background-color);
+
+    --psp-charts--series--color: var(--theme-blue);
+    --psp-charts--series-1--color: var(--theme-blue);
+    --psp-charts--series-2--color: var(--theme-red);
+    --psp-charts--series-3--color: var(--theme-green);
+    --psp-charts--series-4--color: var(--theme-ochre);
+    --psp-charts--series-5--color: var(--theme-violet);
+    --psp-charts--series-6--color: var(--theme-sepia);
+    --psp-charts--series-7--color: var(--theme-teal);
+    --psp-charts--series-8--color: var(--theme-ink-1);
+    --psp-charts--series-9--color: var(--theme-magenta);
+    --psp-charts--series-10--color: var(--theme-olive);
+    --psp-datagrid--series-1--color: var(--theme-blue);
+    --psp-datagrid--series-2--color: var(--theme-red);
+    --psp-datagrid--series-3--color: var(--theme-green);
+    --psp-datagrid--series-4--color: var(--theme-ochre);
+    --psp-datagrid--series-5--color: var(--theme-violet);
+    --psp-datagrid--series-6--color: var(--theme-sepia);
+    --psp-datagrid--series-7--color: var(--theme-teal);
+    --psp-datagrid--series-8--color: var(--theme-ink-1);
+    --psp-datagrid--series-9--color: var(--theme-magenta);
+    --psp-datagrid--series-10--color: var(--theme-olive);
+
+    --psp-charts--gradient--background: linear-gradient(
+        var(--theme-red) 0%,
+        var(--theme-paper-1) 50%,
+        var(--theme-green) 100%
+    );
+
+    --psp-openlayers--tile-url: "http://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png";
+    --psp-openlayers--element--background: var(--theme-paper-0);
+    --psp-openlayers--category-1--color: var(--theme-blue);
+    --psp-openlayers--category-2--color: var(--theme-red);
+    --psp-openlayers--category-3--color: var(--theme-green);
+    --psp-openlayers--category-4--color: var(--theme-ochre);
+    --psp-openlayers--category-5--color: var(--theme-violet);
+    --psp-openlayers--category-6--color: var(--theme-sepia);
+    --psp-openlayers--category-7--color: var(--theme-teal);
+    --psp-openlayers--category-8--color: var(--theme-ink-1);
+    --psp-openlayers--category-9--color: var(--theme-magenta);
+    --psp-openlayers--category-10--color: var(--theme-olive);
+    --psp-openlayers--gradient--background: linear-gradient(
+        var(--theme-red) 0%,
+        var(--theme-paper-1) 50%,
+        var(--theme-green) 100%
+    );
+}
+
+perspective-context-menu[theme="Ledger"],
+perspective-copy-menu[theme="Ledger"],
+perspective-export-menu[theme="Ledger"],
+perspective-dropdown[theme="Ledger"],
+perspective-date-column-style[theme="Ledger"],
+perspective-datetime-column-style[theme="Ledger"],
+perspective-number-column-style[theme="Ledger"],
+perspective-string-column-style[theme="Ledger"] {
+    --theme-paper-0: #fbf7ec;
+    --theme-paper-1: #f4eedd;
+    --theme-paper-2: #e6ddc4;
+    --theme-rule-0: #dfe7d9;
+    --theme-rule-1: #b9cbb3;
+    --theme-ink-0: #2b2a26;
+    --theme-ink-1: #5d574b;
+    --theme-ink-2: #a29c8e;
+    --theme-blue: #1f4e8c;
+    --theme-red: #b3261e;
+    --theme-green: #2e6b3a;
+    --theme-ochre: #b7791f;
+    --theme-violet: #5b3a8c;
+    --theme-sepia: #8a5a2b;
+    --theme-teal: #1d7a7a;
+    --theme-magenta: #a03a6a;
+    --theme-olive: #4a6b1f;
+
+    color: var(--theme-ink-0);
+    --psp--color: var(--theme-ink-0);
+    --psp-active--color: var(--theme-blue);
+    --psp-error--color: var(--theme-red);
+    --psp-inactive--color: var(--theme-ink-2);
+    --psp-inactive--border-color: var(--theme-paper-2);
+    --psp--background-color: var(--theme-paper-0);
+    --psp-active--background: rgba(31, 78, 140, 0.15);
+    --psp-expression--operator--color: var(--theme-ink-1);
+    --psp-expression--function--color: var(--theme-blue);
+    --psp-expression--psp-error--color: var(--theme-red);
+    --psp-warning--color: var(--theme-paper-0);
+    --psp-warning--background: var(--theme-ink-0);
+    --psp-icon-overflow-hint--color: rgba(43, 42, 38, 0.2);
+    --psp-placeholder--background: rgba(162, 156, 142, 0.3);
+    --psp-status-icon--connected--color: var(--theme-green);
+    --psp-status-icon--initializing--color: var(--theme-ochre);
+    --psp-status-icon--psp-error--color: var(--theme-red);
+    --psp-column-type--float--color: var(--theme-blue);
+    --psp-column-type--string--color: var(--theme-red);
+    --psp-column-type--date--color: var(--theme-teal);
+    --psp-column-type--boolean--color: var(--theme-ochre);
+
+    --psp-code-editor--symbol--color: var(--theme-ink-0);
+    --psp-code-editor--literal--color: var(--theme-blue);
+    --psp-code-editor--operator--color: var(--theme-sepia);
+    --psp-code-editor--comment--color: var(--theme-ink-2);
+    --psp-code-editor--column--color: var(--theme-violet);
+
+    background-color: #fbf7ec;
+    border: 1px solid #e6ddc4;
+}

--- a/rust/perspective-viewer/src/themes/monokai.css
+++ b/rust/perspective-viewer/src/themes/monokai.css
@@ -38,14 +38,6 @@ perspective-viewer [theme="Monokai"] {
     --psp-warning--color: #242526;
     --psp-warning--background: var(--psp--color);
 
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
-
     --psp-code-editor--symbol--color: white;
     --psp-code-editor--literal--color: #7dc3f0;
     --psp-code-editor--operator--color: rgb(23, 166, 123);
@@ -212,12 +204,6 @@ perspective-string-column-style[theme="Monokai"] {
     --psp-input--filter: invert(1);
     --psp-warning--color: #242526;
     --psp-warning--background: var(--psp--color);
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
     --psp-code-editor--symbol--color: white;
     --psp-code-editor--literal--color: #7dc3f0;
     --psp-code-editor--operator--color: rgb(23, 166, 123);

--- a/rust/perspective-viewer/src/themes/monokai.css
+++ b/rust/perspective-viewer/src/themes/monokai.css
@@ -23,6 +23,7 @@ perspective-viewer [theme="Monokai"] {
     /* perspective-viewer-pro-dark--colors (overrides) */
     background-color: #242526;
     color: white;
+    color-scheme: dark;
     --psp--color: white;
     --psp-active--color: #2770a9;
     --psp-error--color: #ff9485;
@@ -190,6 +191,7 @@ perspective-string-column-style[theme="Monokai"] {
     /* perspective-viewer-pro-dark--colors (overrides) */
     background-color: #242526;
     color: white;
+    color-scheme: dark;
     --psp--color: white;
     --psp-active--color: #2770a9;
     --psp-error--color: #ff9485;

--- a/rust/perspective-viewer/src/themes/nord.css
+++ b/rust/perspective-viewer/src/themes/nord.css
@@ -1,0 +1,186 @@
+/* ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+ * ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+ * ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+ * ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+ * ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+ * ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+ * ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+ * ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+ * ┃ This file is part of the Perspective library, distributed under the terms ┃
+ * ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+ * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ */
+
+@import "./defaults.css";
+
+perspective-viewer,
+perspective-viewer[theme="Nord"],
+perspective-viewer [theme="Nord"] {
+    --psp-theme-name: "Nord";
+}
+
+perspective-viewer[theme="Nord"],
+perspective-viewer [theme="Nord"] {
+    --theme-bg0: #2e3440;
+    --theme-bg1: #3b4252;
+    --theme-bg2: #434c5e;
+    --theme-bg3: #4c566a;
+
+    --theme-fg0: #eceff4;
+    --theme-fg1: #d8dee9;
+    --theme-fg2: #616e88;
+
+    --theme-frost-0: #8fbcbb;
+    --theme-frost-1: #88c0d0;
+    --theme-frost-2: #81a1c1;
+    --theme-frost-3: #5e81ac;
+
+    --theme-red: #bf616a;
+    --theme-orange: #d08770;
+    --theme-yellow: #ebcb8b;
+    --theme-green: #a3be8c;
+    --theme-purple: #b48ead;
+
+    background-color: var(--theme-bg0);
+    color: var(--theme-fg0);
+    color-scheme: dark;
+    --psp--color: var(--theme-fg1);
+    --psp-active--color: var(--theme-frost-1);
+    --psp-error--color: var(--theme-red);
+    --psp-inactive--color: var(--theme-bg3);
+    --psp-inactive--border-color: var(--theme-bg2);
+    --psp--background-color: var(--theme-bg0);
+    --psp-active--background: rgba(136, 192, 208, 0.35);
+    --psp-expression--operator--color: var(--theme-frost-2);
+    --psp-expression--function--color: var(--theme-frost-1);
+    --psp-expression--psp-error--color: var(--theme-red);
+    --psp-calendar--filter: invert(1);
+    --psp-input--filter: invert(1);
+    --psp-warning--color: var(--theme-bg0);
+    --psp-warning--background: var(--theme-yellow);
+
+    --psp-status-icon--connected--color: var(--theme-green);
+    --psp-status-icon--initializing--color: var(--theme-yellow);
+    --psp-status-icon--psp-error--color: var(--theme-red);
+
+    --psp-code-editor--symbol--color: var(--theme-fg0);
+    --psp-code-editor--literal--color: var(--theme-purple);
+    --psp-code-editor--operator--color: var(--theme-frost-2);
+    --psp-code-editor--comment--color: var(--theme-fg2);
+    --psp-code-editor--column--color: var(--theme-green);
+
+    --psp-datagrid--pos-cell--color: var(--theme-frost-1);
+    --psp-datagrid--neg-cell--color: var(--theme-red);
+
+    --psp-charts--legend--color: var(--theme-fg1);
+    --psp-charts--treemap--labels: var(--theme-fg0);
+    --psp-charts--treemap--hover-highlight: var(--theme-fg0);
+    --psp-charts--tooltip--color: var(--theme-fg0);
+    --psp-charts--axis-ticks--color: var(--theme-fg1);
+    --psp-charts--axis-lines--color: var(--theme-bg3);
+    --psp-charts--gridline--color: var(--theme-bg1);
+    --psp-charts--tooltip--background: var(--theme-bg1);
+    --psp-charts--tooltip--border-color: var(--theme-bg3);
+    --psp-charts--legend--background: var(--psp--background-color);
+
+    --psp-charts--series--color: var(--theme-frost-1);
+    --psp-charts--series-1--color: var(--theme-frost-1);
+    --psp-charts--series-2--color: var(--theme-red);
+    --psp-charts--series-3--color: var(--theme-green);
+    --psp-charts--series-4--color: var(--theme-yellow);
+    --psp-charts--series-5--color: var(--theme-purple);
+    --psp-charts--series-6--color: var(--theme-orange);
+    --psp-charts--series-7--color: var(--theme-frost-3);
+    --psp-charts--series-8--color: var(--theme-frost-0);
+    --psp-charts--series-9--color: var(--theme-frost-2);
+    --psp-charts--series-10--color: var(--theme-fg1);
+    --psp-datagrid--series-1--color: var(--theme-frost-1);
+    --psp-datagrid--series-2--color: var(--theme-red);
+    --psp-datagrid--series-3--color: var(--theme-green);
+    --psp-datagrid--series-4--color: var(--theme-yellow);
+    --psp-datagrid--series-5--color: var(--theme-purple);
+    --psp-datagrid--series-6--color: var(--theme-orange);
+    --psp-datagrid--series-7--color: var(--theme-frost-3);
+    --psp-datagrid--series-8--color: var(--theme-frost-0);
+    --psp-datagrid--series-9--color: var(--theme-frost-2);
+    --psp-datagrid--series-10--color: var(--theme-fg1);
+
+    --psp-charts--gradient--background: linear-gradient(
+        var(--theme-red) 0%,
+        var(--theme-bg0) 50%,
+        var(--theme-frost-1) 100%
+    );
+
+    --psp-openlayers--tile-url: "http://{a-c}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png";
+    --psp-openlayers--attribution--filter: invert(1) hue-rotate(180deg);
+    --psp-openlayers--element--background: var(--theme-bg1);
+    --psp-openlayers--category-1--color: var(--theme-frost-1);
+    --psp-openlayers--category-2--color: var(--theme-red);
+    --psp-openlayers--category-3--color: var(--theme-green);
+    --psp-openlayers--category-4--color: var(--theme-yellow);
+    --psp-openlayers--category-5--color: var(--theme-purple);
+    --psp-openlayers--category-6--color: var(--theme-orange);
+    --psp-openlayers--category-7--color: var(--theme-frost-3);
+    --psp-openlayers--category-8--color: var(--theme-frost-0);
+    --psp-openlayers--category-9--color: var(--theme-frost-2);
+    --psp-openlayers--category-10--color: var(--theme-fg1);
+    --psp-openlayers--gradient--background: linear-gradient(
+        var(--theme-red) 0%,
+        var(--theme-bg0) 50%,
+        var(--theme-frost-1) 100%
+    );
+}
+
+perspective-context-menu[theme="Nord"],
+perspective-copy-menu[theme="Nord"],
+perspective-export-menu[theme="Nord"],
+perspective-dropdown[theme="Nord"],
+perspective-date-column-style[theme="Nord"],
+perspective-datetime-column-style[theme="Nord"],
+perspective-number-column-style[theme="Nord"],
+perspective-string-column-style[theme="Nord"] {
+    --theme-bg0: #2e3440;
+    --theme-bg1: #3b4252;
+    --theme-bg2: #434c5e;
+    --theme-bg3: #4c566a;
+    --theme-fg0: #eceff4;
+    --theme-fg1: #d8dee9;
+    --theme-fg2: #616e88;
+    --theme-frost-0: #8fbcbb;
+    --theme-frost-1: #88c0d0;
+    --theme-frost-2: #81a1c1;
+    --theme-frost-3: #5e81ac;
+    --theme-red: #bf616a;
+    --theme-orange: #d08770;
+    --theme-yellow: #ebcb8b;
+    --theme-green: #a3be8c;
+    --theme-purple: #b48ead;
+
+    background-color: var(--theme-bg0);
+    color: var(--theme-fg0);
+    color-scheme: dark;
+    --psp--color: var(--theme-fg1);
+    --psp-active--color: var(--theme-frost-1);
+    --psp-error--color: var(--theme-red);
+    --psp-inactive--color: var(--theme-bg3);
+    --psp-inactive--border-color: var(--theme-bg2);
+    --psp--background-color: var(--theme-bg0);
+    --psp-active--background: rgba(136, 192, 208, 0.35);
+    --psp-expression--operator--color: var(--theme-frost-2);
+    --psp-expression--function--color: var(--theme-frost-1);
+    --psp-expression--psp-error--color: var(--theme-red);
+    --psp-calendar--filter: invert(1);
+    --psp-input--filter: invert(1);
+    --psp-warning--color: var(--theme-bg0);
+    --psp-warning--background: var(--theme-yellow);
+    --psp-status-icon--connected--color: var(--theme-green);
+    --psp-status-icon--initializing--color: var(--theme-yellow);
+    --psp-status-icon--psp-error--color: var(--theme-red);
+
+    --psp-code-editor--symbol--color: var(--theme-fg0);
+    --psp-code-editor--literal--color: var(--theme-purple);
+    --psp-code-editor--operator--color: var(--theme-frost-2);
+    --psp-code-editor--comment--color: var(--theme-fg2);
+    --psp-code-editor--column--color: var(--theme-green);
+
+    border: 1px solid #434c5e;
+}

--- a/rust/perspective-viewer/src/themes/phosphor.css
+++ b/rust/perspective-viewer/src/themes/phosphor.css
@@ -20,6 +20,7 @@ perspective-viewer [theme="Phosphor"] {
 
 perspective-viewer[theme="Phosphor"],
 perspective-viewer [theme="Phosphor"] {
+    color-scheme: dark;
     /* perspective-viewer-phosphor--colors */
     --theme-bg0: #0a0a0a;
     --theme-bg1: #0d0d0d;
@@ -131,6 +132,7 @@ perspective-date-column-style[theme="Phosphor"],
 perspective-datetime-column-style[theme="Phosphor"],
 perspective-number-column-style[theme="Phosphor"],
 perspective-string-column-style[theme="Phosphor"] {
+    color-scheme: dark;
     /* perspective-viewer-phosphor--colors */
     --theme-bg0: #0a0a0a;
     --theme-bg1: #0d0d0d;

--- a/rust/perspective-viewer/src/themes/phosphor.css
+++ b/rust/perspective-viewer/src/themes/phosphor.css
@@ -49,14 +49,6 @@ perspective-viewer [theme="Phosphor"] {
     --psp-warning--color: var(--theme-bg0);
     --psp-warning--background: var(--theme-amber);
 
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
-
     /* Syntax */
     --psp-code-editor--symbol--color: var(--theme-green-mid);
     --psp-code-editor--literal--color: var(--theme-green-bright);
@@ -165,12 +157,6 @@ perspective-string-column-style[theme="Phosphor"] {
     --psp-input--filter: invert(1) hue-rotate(70deg);
     --psp-warning--color: var(--theme-bg0);
     --psp-warning--background: var(--theme-amber);
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
     --psp-code-editor--symbol--color: var(--theme-green-mid);
     --psp-code-editor--literal--color: var(--theme-green-bright);
     --psp-code-editor--operator--color: var(--theme-amber);

--- a/rust/perspective-viewer/src/themes/pro-dark.css
+++ b/rust/perspective-viewer/src/themes/pro-dark.css
@@ -39,14 +39,6 @@ perspective-viewer [theme="Pro Dark"] {
     --psp-warning--color: #242526;
     --psp-warning--background: var(--psp--color);
 
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
-
     /* Syntax */
     --psp-code-editor--symbol--color: white;
     --psp-code-editor--literal--color: #7dc3f0;
@@ -144,14 +136,6 @@ perspective-string-column-style[theme="Pro Dark"] {
     --psp-input--filter: invert(1);
     --psp-warning--color: #242526;
     --psp-warning--background: var(--psp--color);
-
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
 
     /* Syntax */
     --psp-code-editor--symbol--color: white;

--- a/rust/perspective-viewer/src/themes/pro-dark.css
+++ b/rust/perspective-viewer/src/themes/pro-dark.css
@@ -24,6 +24,7 @@ perspective-viewer [theme="Pro Dark"] {
     /* perspective-viewer-pro-dark--colors (overrides) */
     background-color: #242526;
     color: white;
+    color-scheme: dark;
     --psp--color: white;
     --psp-active--color: #2770a9;
     --psp-error--color: #ff9485;
@@ -122,6 +123,7 @@ perspective-string-column-style[theme="Pro Dark"] {
     /* perspective-viewer-pro-dark--colors (overrides) */
     background-color: #242526;
     color: white;
+    color-scheme: dark;
     --psp--color: white;
     --psp-active--color: #2770a9;
     --psp-error--color: #ff9485;

--- a/rust/perspective-viewer/src/themes/pro.css
+++ b/rust/perspective-viewer/src/themes/pro.css
@@ -16,7 +16,6 @@ perspective-viewer,
 perspective-viewer[theme="Pro Light"],
 perspective-viewer [theme="Pro Light"] {
     --psp-theme-name: "Pro Light";
-
     --psp--color: #161616;
     color: var(--psp--color);
     --psp-inactive--color: #ababab;
@@ -112,4 +111,27 @@ perspective-viewer [theme="Pro Light"] {
         #42b3d5 67.5%,
         #1a237e 100%
     );
+}
+
+perspective-context-menu[theme="Pro Light"],
+perspective-copy-menu[theme="Pro Light"],
+perspective-export-menu[theme="Pro Light"],
+perspective-dropdown[theme="Pro Light"],
+perspective-date-column-style[theme="Pro Light"],
+perspective-datetime-column-style[theme="Pro Light"],
+perspective-number-column-style[theme="Pro Light"],
+perspective-string-column-style[theme="Pro Light"] {
+    --psp--color: #161616;
+    --psp-inactive--color: #ababab;
+    --psp-inactive--border-color: #dadada;
+    --psp-active--color: #2670a9;
+    --psp-error--color: #ff471e;
+    --psp--background-color: #ffffff;
+    --psp-icon-overflow-hint--color: rgba(0, 0, 0, 0.2);
+    --psp-select--background-color: none;
+    --psp-warning--background: #042121;
+    --psp-warning--color: #fdfffd;
+    color: var(--psp--color);
+    background-color: #ffffff;
+    border: 1px solid #ababab;
 }

--- a/rust/perspective-viewer/src/themes/pro.css
+++ b/rust/perspective-viewer/src/themes/pro.css
@@ -16,4 +16,100 @@ perspective-viewer,
 perspective-viewer[theme="Pro Light"],
 perspective-viewer [theme="Pro Light"] {
     --psp-theme-name: "Pro Light";
+
+    --psp--color: #161616;
+    color: var(--psp--color);
+    --psp-inactive--color: #ababab;
+    --psp-inactive--border-color: #dadada;
+    --psp-active--color: #2670a9;
+    --psp-error--color: #ff471e;
+    --psp--background-color: #ffffff;
+    --psp-icon-overflow-hint--color: rgba(0, 0, 0, 0.2);
+    --psp-select--background-color: none;
+    --psp-warning--background: #042121;
+    --psp-warning--color: #fdfffd;
+
+    --psp-icon-overflow-hint--color: #fdfffd;
+    --psp-placeholder--background: #8b868045;
+
+    --psp-button--font-size: 16px;
+    --psp-config-button--padding: 15px 8px 6px 8px;
+    --psp-column-selector--font-size: 16px;
+    --psp-column-type--width: 25px;
+    --psp-select--padding: 0px;
+    --psp-top-panel-row--display: inline-flex;
+    --psp-button--min-width: 33px;
+
+    font-family:
+        "ui-monospace", "SFMono-Regular", "SF Mono", "Menlo", "Consolas",
+        "Liberation Mono", monospace;
+    --psp-interface-monospace--font-family:
+        "ui-monospace", "SFMono-Regular", "SF Mono", "Menlo", "Consolas",
+        "Liberation Mono", monospace;
+
+    --psp-label--webgl-y1--content: "arrow_upward";
+    --psp-label--webgl-y2--content: "arrow_downward";
+    --psp-charts--treemap-axis--lines: none;
+    --psp-charts--tooltip--background: #ffffff;
+    --psp-charts--tooltip--color: #161616;
+    --psp-charts--tooltip--border-color: #ababab;
+    --psp-charts--gridline--color: #eaedef;
+    --psp-charts--axis-ticks--color: #161616;
+    --psp-charts--axis-lines--color: #c5c9d0;
+    --psp-charts--legend--background: var(--psp--background-color);
+    --psp-charts--series--color: rgba(31, 119, 180, 0.8);
+    --psp-charts--series-1--color: #0366d6;
+    --psp-charts--series-2--color: #ff7f0e;
+    --psp-charts--series-3--color: #2ca02c;
+    --psp-charts--series-4--color: #d62728;
+    --psp-charts--series-5--color: #9467bd;
+    --psp-charts--series-6--color: #8c564b;
+    --psp-charts--series-7--color: #e377c2;
+    --psp-charts--series-8--color: #7f7f7f;
+    --psp-charts--series-9--color: #bcbd22;
+    --psp-charts--series-10--color: #17becf;
+    --psp-datagrid--series-1--color: #0366d6;
+    --psp-datagrid--series-2--color: #ff7f0e;
+    --psp-datagrid--series-3--color: #2ca02c;
+    --psp-datagrid--series-4--color: #d62728;
+    --psp-datagrid--series-5--color: #9467bd;
+    --psp-datagrid--series-6--color: #8c564b;
+    --psp-datagrid--series-7--color: #e377c2;
+    --psp-datagrid--series-8--color: #7f7f7f;
+    --psp-datagrid--series-9--color: #bcbd22;
+    --psp-datagrid--series-10--color: #17becf;
+    --psp-charts--gradient--background: linear-gradient(
+        #4d342f 0%,
+        #e4521b 22.5%,
+        #feeb65 42.5%,
+        #f0f0f0 50%,
+        #dcedc8 57.5%,
+        #42b3d5 67.5%,
+        #1a237e 100%
+    );
+
+    --psp-datagrid--pos-cell--color: #338dcd;
+    --psp-datagrid--neg-cell--color: #ff471e;
+
+    --psp-openlayers--tile-url: "http://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png";
+    --psp-openlayers--element--background: #fff;
+    --psp-openlayers--category-1--color: #0366d6;
+    --psp-openlayers--category-2--color: #ff7f0e;
+    --psp-openlayers--category-3--color: #2ca02c;
+    --psp-openlayers--category-4--color: #d62728;
+    --psp-openlayers--category-5--color: #9467bd;
+    --psp-openlayers--category-6--color: #8c564b;
+    --psp-openlayers--category-7--color: #e377c2;
+    --psp-openlayers--category-8--color: #7f7f7f;
+    --psp-openlayers--category-9--color: #bcbd22;
+    --psp-openlayers--category-10--color: #17becf;
+    --psp-openlayers--gradient--background: linear-gradient(
+        #4d342f 0%,
+        #e4521b 22.5%,
+        #feeb65 42.5%,
+        #f0f0f0 50%,
+        #dcedc8 57.5%,
+        #42b3d5 67.5%,
+        #1a237e 100%
+    );
 }

--- a/rust/perspective-viewer/src/themes/solarized-dark.css
+++ b/rust/perspective-viewer/src/themes/solarized-dark.css
@@ -68,14 +68,6 @@ perspective-viewer [theme="Solarized Dark"] {
     --psp-inactive--border-color: var(--psp-inactive--color);
     --psp--background-color: #073642;
 
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
-
     /* perspective-viewer-solarized-dark--webgl */
     --psp-charts--treemap--labels: white;
     --psp-charts--treemap--hover-highlight: white;
@@ -117,14 +109,6 @@ perspective-string-column-style[theme="Solarized Dark"] {
     --psp-inactive--color: #586e75;
     --psp-inactive--border-color: var(--psp-inactive--color);
     --psp--background-color: #073642;
-
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
 
     background-color: #073642;
 }

--- a/rust/perspective-viewer/src/themes/solarized-dark.css
+++ b/rust/perspective-viewer/src/themes/solarized-dark.css
@@ -23,6 +23,7 @@ perspective-viewer [theme="Solarized Dark"] {
     /* perspective-viewer-solarized--colors */
     color: #586e75;
     background-color: #eee8d5;
+    color-scheme: dark;
     --psp--color: #586e75;
     --psp-active--color: #268bd2;
     --psp-error--color: #cb4b16;
@@ -93,6 +94,7 @@ perspective-number-column-style[theme="Solarized Dark"],
 perspective-string-column-style[theme="Solarized Dark"] {
     /* perspective-viewer-solarized--colors */
     color: #586e75;
+    color-scheme: dark;
     --psp--color: #586e75;
     --psp-active--color: #268bd2;
     --psp-error--color: #cb4b16;

--- a/rust/perspective-viewer/src/themes/themes.css
+++ b/rust/perspective-viewer/src/themes/themes.css
@@ -12,12 +12,17 @@
 
 @import "./pro.css";
 @import "./pro-dark.css";
+@import "./blueprint.css";
+@import "./botanical.css";
+@import "./dracula.css";
+@import "./eggplant.css";
+@import "./gruvbox.css";
+@import "./gruvbox-dark.css";
+@import "./ledger.css";
 @import "./monokai.css";
+@import "./nord.css";
+@import "./phosphor.css";
 @import "./solarized.css";
 @import "./solarized-dark.css";
 @import "./vaporwave.css";
-@import "./gruvbox.css";
-@import "./gruvbox-dark.css";
-@import "./dracula.css";
-@import "./botanical.css";
-@import "./phosphor.css";
+@import "./velvet.css";

--- a/rust/perspective-viewer/src/themes/vaporwave.css
+++ b/rust/perspective-viewer/src/themes/vaporwave.css
@@ -23,6 +23,7 @@ perspective-viewer [theme="Vaporwave"] {
     /* perspective-viewer-pro-dark--colors (overrides) */
     background-color: #242526;
     color: white;
+    color-scheme: dark;
     --psp--color: white;
     --psp-active--color: #2770a9;
     --psp-error--color: #ff9485;
@@ -200,6 +201,7 @@ perspective-string-column-style[theme="Vaporwave"] {
     /* perspective-viewer-pro-dark--colors (overrides) */
     background-color: #242526;
     color: white;
+    color-scheme: dark;
     --psp--color: white;
     --psp-active--color: #2770a9;
     --psp-error--color: #ff9485;

--- a/rust/perspective-viewer/src/themes/vaporwave.css
+++ b/rust/perspective-viewer/src/themes/vaporwave.css
@@ -38,14 +38,6 @@ perspective-viewer [theme="Vaporwave"] {
     --psp-warning--color: #242526;
     --psp-warning--background: var(--psp--color);
 
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
-
     --psp-code-editor--symbol--color: white;
     --psp-code-editor--literal--color: #7dc3f0;
     --psp-code-editor--operator--color: rgb(23, 166, 123);
@@ -222,12 +214,6 @@ perspective-string-column-style[theme="Vaporwave"] {
     --psp-input--filter: invert(1);
     --psp-warning--color: #242526;
     --psp-warning--background: var(--psp--color);
-    --psp-icon--select-arrow--mask-image: var(
-        --psp-icon--select-arrow-light--mask-image
-    );
-    --psp-icon--select-arrow-hover--mask-image: var(
-        --psp-icon--select-arrow-dark--mask-image
-    );
     --psp-code-editor--symbol--color: white;
     --psp-code-editor--literal--color: #7dc3f0;
     --psp-code-editor--operator--color: rgb(23, 166, 123);

--- a/rust/perspective-viewer/src/themes/velvet.css
+++ b/rust/perspective-viewer/src/themes/velvet.css
@@ -1,0 +1,192 @@
+/* ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+ * ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+ * ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+ * ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+ * ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+ * ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+ * ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+ * ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+ * ┃ This file is part of the Perspective library, distributed under the terms ┃
+ * ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+ * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ */
+
+@import "./defaults.css";
+
+perspective-viewer,
+perspective-viewer[theme="Velvet"],
+perspective-viewer [theme="Velvet"] {
+    --psp-theme-name: "Velvet";
+}
+
+perspective-viewer[theme="Velvet"],
+perspective-viewer [theme="Velvet"] {
+    --theme-bg0: #3a0d14;
+    --theme-bg1: #4a1119;
+    --theme-bg2: #5c1822;
+    --theme-bg3: #7a2431;
+    --theme-fg0: #fff5f7;
+    --theme-fg1: #f3c9d3;
+    --theme-fg2: #a8606f;
+    --theme-white: #ffffff;
+    --theme-pink: #ff8fb8;
+    --theme-pink-bright: #ffb3cf;
+    --theme-rose: #ff5c8d;
+    --theme-blush: #ffd6e2;
+    --theme-gold: #f2c078;
+    --theme-lilac: #d9b3ff;
+    --theme-peach: #ffcba4;
+    --theme-amber: #ffd166;
+    --theme-mint: #8fe3c8;
+    --theme-sky: #9ccfff;
+    --theme-periwinkle: #a3a8ff;
+    --theme-sage: #c5d99a;
+
+    background-color: var(--theme-bg0);
+    color: var(--theme-fg0);
+    color-scheme: dark;
+    --psp--color: var(--theme-fg1);
+    --psp-active--color: var(--theme-pink);
+    --psp-error--color: var(--theme-amber);
+    --psp-inactive--color: var(--theme-fg2);
+    --psp-inactive--border-color: var(--theme-bg3);
+    --psp--background-color: var(--theme-bg0);
+    --psp-active--background: rgba(255, 143, 184, 0.3);
+    --psp-expression--operator--color: var(--theme-pink-bright);
+    --psp-expression--function--color: var(--theme-pink);
+    --psp-expression--psp-error--color: var(--theme-amber);
+    --psp-calendar--filter: invert(1);
+    --psp-input--filter: invert(1);
+    --psp-warning--color: var(--theme-bg0);
+    --psp-warning--background: var(--theme-blush);
+
+    --psp-status-icon--connected--color: var(--theme-pink);
+    --psp-status-icon--initializing--color: var(--theme-blush);
+    --psp-status-icon--psp-error--color: var(--theme-amber);
+
+    --psp-code-editor--symbol--color: var(--theme-fg0);
+    --psp-code-editor--literal--color: var(--theme-pink-bright);
+    --psp-code-editor--operator--color: var(--theme-pink-bright);
+    --psp-code-editor--comment--color: var(--theme-fg2);
+    --psp-code-editor--column--color: var(--theme-lilac);
+
+    --psp-datagrid--pos-cell--color: var(--theme-white);
+    --psp-datagrid--neg-cell--color: var(--theme-rose);
+
+    --psp-charts--legend--color: var(--theme-fg1);
+    --psp-charts--treemap--labels: var(--theme-fg0);
+    --psp-charts--treemap--hover-highlight: var(--theme-fg0);
+    --psp-charts--tooltip--color: var(--theme-fg0);
+    --psp-charts--axis-ticks--color: var(--theme-fg1);
+    --psp-charts--axis-lines--color: var(--theme-bg3);
+    --psp-charts--gridline--color: var(--theme-bg2);
+    --psp-charts--tooltip--background: var(--theme-bg1);
+    --psp-charts--tooltip--border-color: var(--theme-bg3);
+    --psp-charts--legend--background: var(--psp--background-color);
+
+    --psp-charts--series--color: var(--theme-white);
+    --psp-charts--series-1--color: var(--theme-fg1);
+    --psp-charts--series-2--color: var(--theme-pink);
+    --psp-charts--series-3--color: var(--theme-gold);
+    --psp-charts--series-4--color: var(--theme-lilac);
+    --psp-charts--series-5--color: var(--theme-mint);
+    --psp-charts--series-6--color: var(--theme-rose);
+    --psp-charts--series-7--color: var(--theme-sky);
+    --psp-charts--series-8--color: var(--theme-peach);
+    --psp-charts--series-9--color: var(--theme-periwinkle);
+    --psp-charts--series-10--color: var(--theme-sage);
+    --psp-datagrid--series-1--color: var(--theme-fg1);
+    --psp-datagrid--series-2--color: var(--theme-pink);
+    --psp-datagrid--series-3--color: var(--theme-gold);
+    --psp-datagrid--series-4--color: var(--theme-lilac);
+    --psp-datagrid--series-5--color: var(--theme-mint);
+    --psp-datagrid--series-6--color: var(--theme-rose);
+    --psp-datagrid--series-7--color: var(--theme-sky);
+    --psp-datagrid--series-8--color: var(--theme-peach);
+    --psp-datagrid--series-9--color: var(--theme-periwinkle);
+    --psp-datagrid--series-10--color: var(--theme-sage);
+
+    --psp-charts--gradient--background: linear-gradient(
+        var(--theme-rose) 0%,
+        var(--theme-bg0) 50%,
+        var(--theme-white) 100%
+    );
+
+    --psp-openlayers--tile-url: "http://{a-c}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png";
+    --psp-openlayers--attribution--filter: invert(1) hue-rotate(180deg);
+    --psp-openlayers--element--background: var(--theme-bg1);
+    --psp-openlayers--category-1--color: var(--theme-fg1);
+    --psp-openlayers--category-2--color: var(--theme-pink);
+    --psp-openlayers--category-3--color: var(--theme-gold);
+    --psp-openlayers--category-4--color: var(--theme-lilac);
+    --psp-openlayers--category-5--color: var(--theme-mint);
+    --psp-openlayers--category-6--color: var(--theme-rose);
+    --psp-openlayers--category-7--color: var(--theme-sky);
+    --psp-openlayers--category-8--color: var(--theme-peach);
+    --psp-openlayers--category-9--color: var(--theme-periwinkle);
+    --psp-openlayers--category-10--color: var(--theme-sage);
+    --psp-openlayers--gradient--background: linear-gradient(
+        var(--theme-rose) 0%,
+        var(--theme-bg0) 50%,
+        var(--theme-white) 100%
+    );
+}
+
+perspective-context-menu[theme="Velvet"],
+perspective-copy-menu[theme="Velvet"],
+perspective-export-menu[theme="Velvet"],
+perspective-dropdown[theme="Velvet"],
+perspective-date-column-style[theme="Velvet"],
+perspective-datetime-column-style[theme="Velvet"],
+perspective-number-column-style[theme="Velvet"],
+perspective-string-column-style[theme="Velvet"] {
+    --theme-bg0: #3a0d14;
+    --theme-bg1: #4a1119;
+    --theme-bg2: #5c1822;
+    --theme-bg3: #7a2431;
+    --theme-fg0: #fff5f7;
+    --theme-fg1: #f3c9d3;
+    --theme-fg2: #a8606f;
+    --theme-white: #ffffff;
+    --theme-pink: #ff8fb8;
+    --theme-pink-bright: #ffb3cf;
+    --theme-rose: #ff5c8d;
+    --theme-blush: #ffd6e2;
+    --theme-gold: #f2c078;
+    --theme-lilac: #d9b3ff;
+    --theme-peach: #ffcba4;
+    --theme-amber: #ffd166;
+    --theme-mint: #8fe3c8;
+    --theme-sky: #9ccfff;
+    --theme-periwinkle: #a3a8ff;
+    --theme-sage: #c5d99a;
+
+    background-color: var(--theme-bg0);
+    color: var(--theme-fg0);
+    color-scheme: dark;
+    --psp--color: var(--theme-fg1);
+    --psp-active--color: var(--theme-pink);
+    --psp-error--color: var(--theme-amber);
+    --psp-inactive--color: var(--theme-fg2);
+    --psp-inactive--border-color: var(--theme-bg3);
+    --psp--background-color: var(--theme-bg0);
+    --psp-active--background: rgba(255, 143, 184, 0.3);
+    --psp-expression--operator--color: var(--theme-pink-bright);
+    --psp-expression--function--color: var(--theme-pink);
+    --psp-expression--psp-error--color: var(--theme-amber);
+    --psp-calendar--filter: invert(1);
+    --psp-input--filter: invert(1);
+    --psp-warning--color: var(--theme-bg0);
+    --psp-warning--background: var(--theme-blush);
+
+    --psp-status-icon--connected--color: var(--theme-pink);
+    --psp-status-icon--initializing--color: var(--theme-blush);
+    --psp-status-icon--psp-error--color: var(--theme-amber);
+
+    --psp-code-editor--symbol--color: var(--theme-fg0);
+    --psp-code-editor--literal--color: var(--theme-pink-bright);
+    --psp-code-editor--operator--color: var(--theme-pink-bright);
+    --psp-code-editor--comment--color: var(--theme-fg2);
+    --psp-code-editor--column--color: var(--theme-lilac);
+
+    border: 1px solid #7a2431;
+}

--- a/rust/perspective-viewer/src/ts/column-format.ts
+++ b/rust/perspective-viewer/src/ts/column-format.ts
@@ -83,23 +83,67 @@ const DATE_LEGACY_DEFAULTS: Intl.DateTimeFormatOptions = {
     dateStyle: "short",
 };
 
+function mergeNumberOptions(
+    base: Intl.NumberFormatOptions,
+    cfg?: NumberFormatConfig,
+): Intl.NumberFormatOptions {
+    const explicit: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(cfg ?? {})) {
+        if (v !== undefined && v !== null) {
+            explicit[k] = v;
+        }
+    }
+
+    const merged: Record<string, unknown> = { ...base };
+    if (
+        "minimumFractionDigits" in explicit ||
+        "maximumFractionDigits" in explicit
+    ) {
+        delete merged.minimumFractionDigits;
+        delete merged.maximumFractionDigits;
+    }
+
+    if (
+        "minimumSignificantDigits" in explicit ||
+        "maximumSignificantDigits" in explicit
+    ) {
+        delete merged.minimumSignificantDigits;
+        delete merged.maximumSignificantDigits;
+    }
+
+    return Object.assign(merged, explicit) as Intl.NumberFormatOptions;
+}
+
+/**
+ * `defaults` is the calling plugin's declared default format, filling in
+ * the fields `cfg` leaves unset.
+ */
 export function createNumberFormatter(
     type: string,
     cfg?: NumberFormatConfig,
+    defaults?: NumberFormatConfig,
 ): Intl.NumberFormat {
     // ts-rs renders serde-absent keys as `T | null`; the wire never
     // carries an explicit `null` (`skip_serializing_if`), and
     // `Intl.NumberFormat` treats both absent and `undefined` the same, so
     // the cast is presentation-only.
-    const opts = (cfg ??
+    const base = ((defaults as Intl.NumberFormatOptions | undefined) ??
         NUMERIC_LEGACY_DEFAULTS[type] ??
         {}) as Intl.NumberFormatOptions;
+
+    const opts = cfg ? mergeNumberOptions(base, cfg) : base;
     return new Intl.NumberFormat(navigator.languages as string[], opts);
 }
 
+/**
+ * `defaults` is the calling plugin's declared default `date_format`,
+ * applied only when `cfg` is wholly absent.
+ */
 export function createDatetimeFormatter(
     cfg?: DateFormatConfig,
+    defaults?: DateFormatConfig,
 ): Intl.DateTimeFormat {
+    cfg = cfg ?? defaults;
     if (!cfg || !("format" in cfg)) {
         const preset = simple_config(cfg);
         const opts: Intl.DateTimeFormatOptions = {
@@ -158,10 +202,16 @@ export function createDatetimeFormatter(
     return new Intl.DateTimeFormat(navigator.languages as string[], opts);
 }
 
+/**
+ * `defaults` follows the same contract as
+ * [`createDatetimeFormatter`]: the plugin's declared default
+ * `date_format`, applied only when `cfg` is wholly absent.
+ */
 export function createDateFormatter(
     cfg?: DateFormatConfig,
+    defaults?: DateFormatConfig,
 ): Intl.DateTimeFormat {
-    const preset = simple_config(cfg);
+    const preset = simple_config(cfg ?? defaults);
     const opts: Intl.DateTimeFormatOptions = {
         timeZone: "utc",
         dateStyle:

--- a/rust/perspective-viewer/test/html/debug_plugins.js
+++ b/rust/perspective-viewer/test/html/debug_plugins.js
@@ -38,6 +38,20 @@ class DebugStyledPlugin extends BasePlugin {
                         { value: "READ_ONLY", label: "Read-only" },
                     ],
                 },
+                {
+                    kind: "Group",
+                    key: "legend",
+                    fields: [
+                        { kind: "Bool", key: "legend_on", default: false },
+                        {
+                            kind: "Number",
+                            key: "legend_width",
+                            default: 120,
+                            min: 0,
+                            max: 512,
+                        },
+                    ],
+                },
             ],
         };
     }
@@ -62,6 +76,21 @@ class DebugStyledPlugin extends BasePlugin {
                 default: "#2771a8",
             });
             fields.push({ kind: "NumberFormat" });
+
+            fields.push({
+                kind: "Group",
+                key: "fg",
+                fields: [
+                    { kind: "Bool", key: "fg_flag", default: false },
+                    { kind: "Color", key: "fg_color", default: "#ff471e" },
+                ],
+            });
+
+            fields.push({
+                kind: "Group",
+                key: "bg",
+                fields: [{ kind: "Bool", key: "bg_flag", default: false }],
+            });
         } else if (type === "date") {
             fields.push({ kind: "DatetimeFormat" });
         } else if (type === "datetime") {

--- a/rust/perspective-viewer/test/html/debug_plugins.js
+++ b/rust/perspective-viewer/test/html/debug_plugins.js
@@ -174,12 +174,52 @@ class DebugAltPlugin extends DebugStyledPlugin {
     }
 }
 
+class DebugFormatPlugin extends DebugStyledPlugin {
+    get_static_config() {
+        return {
+            name: "Debug Format",
+            select_mode: "toggle",
+            config_column_names: ["Columns"],
+            priority: 0,
+            can_render_column_styles: true,
+        };
+    }
+
+    plugin_config_schema() {
+        return { fields: [] };
+    }
+
+    column_config_schema(type) {
+        const fields = [];
+        if (type === "integer" || type === "float") {
+            fields.push({
+                kind: "NumberFormat",
+                default: {
+                    notation: "compact",
+                    compactDisplay: "short",
+                    minimumFractionDigits: 0,
+                    maximumFractionDigits: 1,
+                },
+            });
+        } else if (type === "date" || type === "datetime") {
+            fields.push({
+                kind: "DatetimeFormat",
+                default: { dateStyle: "medium", timeStyle: "disabled" },
+            });
+        }
+
+        return { fields };
+    }
+}
+
 customElements.define("perspective-viewer-debug-styled", DebugStyledPlugin);
 customElements.define("perspective-viewer-debug-alt", DebugAltPlugin);
+customElements.define("perspective-viewer-debug-format", DebugFormatPlugin);
 
 const Viewer = customElements.get("perspective-viewer");
 Viewer.registerPlugin("perspective-viewer-debug-styled");
 Viewer.registerPlugin("perspective-viewer-debug-alt");
+Viewer.registerPlugin("perspective-viewer-debug-format");
 
 async function load() {
     const resp = await fetch(

--- a/rust/perspective-viewer/test/js/agent/agent_http.spec.ts
+++ b/rust/perspective-viewer/test/js/agent/agent_http.spec.ts
@@ -16,7 +16,7 @@
 // with no live LLM. The offline `agent.spec.ts` covers the same tool loop
 // over the in-page engine transport; this suite covers what only HTTP has.
 
-import { test, expect } from "../helpers.ts";
+import { test, expect, compareInnerHTMLToSnapshot } from "../helpers.ts";
 
 const BASE_URL = "https://fake-llm.example/v1";
 
@@ -238,7 +238,7 @@ test.describe("llm-agent http transport", () => {
         await expect(log.locator(".chat-pending")).toBeVisible();
         await page.locator("perspective-viewer #chat_stop_button").click();
         await expect(log.locator(".chat-error")).toHaveText("Stopped");
-        await expect(log.locator(".chat-pending")).toHaveCount(0);
+        await compareInnerHTMLToSnapshot(log, ["stopped"]);
         await expect(input).toBeEnabled();
     });
 });

--- a/rust/perspective-viewer/test/js/agent/chat_panel.spec.ts
+++ b/rust/perspective-viewer/test/js/agent/chat_panel.spec.ts
@@ -14,7 +14,7 @@
 // OpenAI-compatible engine as `agent.spec.ts`. The chat panel is a pure view
 // over the shared agent slot, so the transcript must survive tab switches.
 
-import { test, expect } from "../helpers.ts";
+import { test, expect, compareInnerHTMLToSnapshot } from "../helpers.ts";
 
 test.beforeEach(async ({ page }) => {
     await page.goto("/rust/perspective-viewer/test/html/superstore.html");
@@ -153,18 +153,11 @@ test.describe("llm-agent chat panel", () => {
         await input.press("Enter");
 
         const log = page.locator("perspective-viewer #chat_log");
-        await expect(log.locator(".chat-user")).toHaveText(
-            "Show me sales by state",
-        );
-
         await expect(
             log.locator(".chat-assistant:not(.chat-pending)"),
         ).toHaveText("Grouped by state.", { timeout: 10000 });
 
-        await expect(log.locator(".chat-tool-chip")).toHaveText([
-            "get_schema",
-            "set_view_config",
-        ]);
+        await compareInnerHTMLToSnapshot(log);
 
         const config = await page.evaluate(async () => {
             return await document.querySelector("perspective-viewer").save();
@@ -185,7 +178,7 @@ test.describe("llm-agent chat panel", () => {
         await expect(log.locator(".chat-pending")).toBeVisible();
         await page.locator("perspective-viewer #chat_stop_button").click();
         await expect(log.locator(".chat-error")).toHaveText("Stopped");
-        await expect(log.locator(".chat-pending")).toHaveCount(0);
+        await compareInnerHTMLToSnapshot(log, ["stopped"]);
         await expect(input).toBeEnabled();
     });
 
@@ -218,8 +211,7 @@ test.describe("llm-agent chat panel", () => {
         );
 
         await expect(message).toHaveText("Streaming done");
-        await expect(message.locator("strong")).toHaveText("Streaming");
-        await expect(log.locator(".chat-streaming")).toHaveCount(0);
+        await compareInnerHTMLToSnapshot(log, ["final"]);
     });
 
     test("reasoning follows its tail until the reader scrolls away", async ({
@@ -301,8 +293,6 @@ test.describe("llm-agent chat panel", () => {
             log.locator(".chat-assistant:not(.chat-pending)"),
         ).toHaveText("That expression is invalid.");
 
-        const chip = log.locator(".chat-tool-chip-error");
-        await expect(chip).toHaveText("set_view_config");
-        await expect(chip).toHaveAttribute("title", /\n\n.*expressions/s);
+        await compareInnerHTMLToSnapshot(log);
     });
 });

--- a/rust/perspective-viewer/test/js/agent/markdown_fixtures.spec.ts
+++ b/rust/perspective-viewer/test/js/agent/markdown_fixtures.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "../helpers.ts";
+import { test, expect, compareInnerHTMLToSnapshot } from "../helpers.ts";
 
 test.beforeEach(async ({ page }) => {
     await page.goto("/rust/perspective-viewer/test/html/superstore.html");
@@ -90,25 +90,6 @@ test.describe("llm-agent markdown fixtures", () => {
                 "3. Rendered the chart",
         );
 
-        await expect(message.locator("h2")).toHaveText("Analysis");
-        const items = message.locator("ol > li");
-        await expect(items).toHaveCount(3);
-        await expect(items.nth(0).locator("code")).toHaveText("get_schema");
-        await expect(items.nth(1).locator("pre code")).toHaveText(
-            '{ "group_by": ["State"] }\n',
-        );
-
-        await expect(items.nth(1).locator("pre code")).toHaveAttribute(
-            "data-lang",
-            "json",
-        );
-
-        // Code blocks scroll horizontally, so they take the viewer's
-        // scrollbar styling rather than the browser default.
-        await expect(items.nth(1).locator("pre")).toHaveClass(/\bscrollable\b/);
-        const inner = items.nth(1).locator("ul > li");
-        await expect(inner).toHaveCount(2);
-        await expect(inner.nth(0).locator("strong")).toHaveText("State");
-        await expect(inner.nth(1).locator("em")).toHaveText("descending");
+        await compareInnerHTMLToSnapshot(message);
     });
 });

--- a/rust/perspective-viewer/test/js/column_settings/attributes_tab.spec.ts
+++ b/rust/perspective-viewer/test/js/column_settings/attributes_tab.spec.ts
@@ -10,7 +10,12 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect, PageView } from "../helpers.ts";
+import {
+    test,
+    expect,
+    PageView,
+    compareInnerHTMLToSnapshot,
+} from "../helpers.ts";
 
 test.beforeEach(async ({ page }) => {
     await page.goto("/rust/perspective-viewer/test/html/superstore-debug.html");
@@ -38,9 +43,15 @@ test.describe("Attributes Tab", () => {
         await expr.editBtn.click();
         let input = view.columnSettingsSidebar.nameInput;
         await view.columnSettingsSidebar.openTab("Style");
-        await expect(input).toBeDisabled();
+        await compareInnerHTMLToSnapshot(
+            view.columnSettingsSidebar.nameInputWrapper,
+            ["style-tab"],
+        );
         await view.columnSettingsSidebar.openTab("Attributes");
-        await expect(input).toBeEnabled();
+        await compareInnerHTMLToSnapshot(
+            view.columnSettingsSidebar.nameInputWrapper,
+            ["attributes-tab"],
+        );
     });
 
     test("Empty expression names", async ({ page }) => {
@@ -51,9 +62,9 @@ test.describe("Attributes Tab", () => {
         await view.settingsPanel.createNewExpression("", expr_value);
         // Empty text matches expression
         let input = view.columnSettingsSidebar.nameInput;
-        expect(await input.evaluate((input) => input!.value)).toBe("");
-        expect(await input.evaluate((input) => input!.placeholder)).toBe(
-            expr_value,
+        await compareInnerHTMLToSnapshot(
+            view.columnSettingsSidebar.nameInputWrapper,
+            ["header"],
         );
         // Reopening the column shows an empty header with placeholder text that matches
         await view.columnSettingsSidebar.closeBtn.click();
@@ -62,9 +73,10 @@ test.describe("Attributes Tab", () => {
                 expr_value,
             );
         await expr.editBtn.click();
-        expect(await input.evaluate((input) => input!.value)).toBe("");
-        expect(await input.evaluate((input) => input!.placeholder)).toBe(
-            expr_value,
+        await input.waitFor();
+        await compareInnerHTMLToSnapshot(
+            view.columnSettingsSidebar.nameInputWrapper,
+            ["header"],
         );
         // Expression alias is the expression on serialization
         let config = await view.save();
@@ -262,10 +274,7 @@ test.describe("Column settings header drafts", () => {
         await sidebar.attributesTab.saveBtn.click();
 
         await expect(sidebar.nameInput).toHaveValue("renamed");
-        await expect(sidebar.nameInput).toBeEnabled();
-        await expect(sidebar.attributesTab.saveBtn).toBeDisabled();
-        await expect(sidebar.nameInputWrapper).not.toHaveClass(/edited/);
-        expect(await sidebar.getTabs()).toEqual(["Style", "Attributes"]);
+        await compareInnerHTMLToSnapshot(sidebar.container, ["retargeted"]);
 
         const config = await view.save();
         expect(Object.keys(config.expressions ?? {})).toEqual(["renamed"]);

--- a/rust/perspective-viewer/test/js/column_settings/format_defaults.spec.ts
+++ b/rust/perspective-viewer/test/js/column_settings/format_defaults.spec.ts
@@ -1,0 +1,230 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { test, expect, PageView } from "../helpers.ts";
+import type { Locator } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("/rust/perspective-viewer/test/html/superstore-debug.html");
+    await page.evaluate(async () => {
+        while (!(window as any)["__TEST_PERSPECTIVE_READY__"]) {
+            await new Promise((x) => setTimeout(x, 10));
+        }
+    });
+});
+
+async function openStyleTab(view: PageView, column: string) {
+    const col = await view.settingsPanel.activeColumns.getColumnByName(column);
+    await view.assureColumnSettingsOpen(col);
+    await view.columnSettingsSidebar.container.waitFor({ state: "visible" });
+}
+
+function field(view: PageView, label: string): Locator {
+    return view.columnSettingsSidebar.container.locator(
+        `#${label}-label + div`,
+    );
+}
+
+test.describe("Number format defaults", () => {
+    test("editor shows built-in defaults without an override", async ({
+        page,
+    }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Styled",
+            columns: ["Sales"],
+        });
+
+        await openStyleTab(view, "Sales");
+        const frac = field(view, "fractional-digits");
+        await expect(frac.locator("input.parameter-min")).toHaveValue("2");
+        await expect(frac.locator("input.parameter-max")).toHaveValue("2");
+
+        const sig = field(view, "significant-digits");
+        await expect(sig.locator("input.parameter-min")).toHaveValue("1");
+        await expect(sig.locator("input.parameter-max")).toHaveValue("21");
+
+        const notation = field(view, "notation");
+        await expect(notation.locator("select")).toHaveValue("Standard");
+    });
+
+    test("editor shows the plugin's declared default override", async ({
+        page,
+    }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Format",
+            columns: ["Sales"],
+        });
+
+        await openStyleTab(view, "Sales");
+        const frac = field(view, "fractional-digits");
+        await expect(frac.locator("input.parameter-min")).toHaveValue("0");
+        await expect(frac.locator("input.parameter-max")).toHaveValue("1");
+
+        const notation = field(view, "notation");
+        await expect(notation.locator("select")).toHaveValue("Compact");
+
+        const compact = field(view, "compact-display");
+        await expect(compact.locator("select")).toHaveValue("Short");
+    });
+
+    test("max significant digits round-trips", async ({ page }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Styled",
+            columns: ["Sales"],
+        });
+
+        await openStyleTab(view, "Sales");
+        const sig = field(view, "significant-digits");
+        await sig.locator("input.parameter-max").fill("5");
+        await expect(sig.locator("input.parameter-max")).toHaveValue("5");
+
+        const config = (await view.save()) as any;
+        expect(config.columns_config).toEqual({
+            Sales: {
+                number_format: {
+                    minimumSignificantDigits: 1,
+                    maximumSignificantDigits: 5,
+                },
+            },
+        });
+
+        await expect(sig.locator("input.parameter-max")).toHaveValue("5");
+    });
+
+    test("unrelated edits serialize sparsely under an override", async ({
+        page,
+    }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Format",
+            columns: ["Sales"],
+        });
+
+        await openStyleTab(view, "Sales");
+        const digits = field(view, "minimum-integer-digits");
+        await digits.locator("input.parameter").fill("2");
+
+        const config = (await view.save()) as any;
+        expect(config.columns_config).toEqual({
+            Sales: { number_format: { minimumIntegerDigits: 2 } },
+        });
+    });
+
+    test("built-in values serialize explicitly under an override", async ({
+        page,
+    }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Format",
+            columns: ["Sales"],
+        });
+
+        await openStyleTab(view, "Sales");
+        const frac = field(view, "fractional-digits");
+        await frac.locator("input.parameter-max").fill("2");
+        await frac.locator("input.parameter-min").fill("2");
+
+        const config = (await view.save()) as any;
+        expect(config.columns_config).toEqual({
+            Sales: {
+                number_format: {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                },
+            },
+        });
+    });
+
+    test("choosing standard notation under a compact override serializes", async ({
+        page,
+    }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Format",
+            columns: ["Sales"],
+        });
+
+        await openStyleTab(view, "Sales");
+        const notation = field(view, "notation");
+        await notation.locator("select").selectOption("Standard");
+
+        const config = (await view.save()) as any;
+        expect(config.columns_config).toEqual({
+            Sales: { number_format: { notation: "standard" } },
+        });
+    });
+});
+
+test.describe("Datetime format defaults", () => {
+    test("editor shows built-in preset without an override", async ({
+        page,
+    }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Styled",
+            columns: ["Order Date"],
+        });
+
+        await openStyleTab(view, "Order Date");
+        const dateStyle = field(view, "date-style");
+        await expect(dateStyle.locator("select")).toHaveValue("short");
+
+        await dateStyle.locator("select").selectOption("medium");
+        const config = (await view.save()) as any;
+        expect(config.columns_config["Order Date"].date_format).toEqual({
+            dateStyle: "medium",
+        });
+    });
+
+    test("editor shows the plugin's declared preset override", async ({
+        page,
+    }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Format",
+            columns: ["Order Date"],
+        });
+
+        await openStyleTab(view, "Order Date");
+        const dateStyle = field(view, "date-style");
+        await expect(dateStyle.locator("select")).toHaveValue("medium");
+    });
+
+    test("legacy preset serializes under an override", async ({ page }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Format",
+            columns: ["Order Date"],
+        });
+
+        await openStyleTab(view, "Order Date");
+        const dateStyle = field(view, "date-style");
+        await dateStyle.locator("select").selectOption("short");
+
+        const config = (await view.save()) as any;
+        expect(config.columns_config["Order Date"].date_format).toEqual({
+            timeStyle: "disabled",
+        });
+    });
+});

--- a/rust/perspective-viewer/test/js/column_settings/palette_gradient.spec.ts
+++ b/rust/perspective-viewer/test/js/column_settings/palette_gradient.spec.ts
@@ -10,7 +10,12 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect, PageView } from "../helpers.ts";
+import {
+    test,
+    expect,
+    PageView,
+    compareInnerHTMLToSnapshot,
+} from "../helpers.ts";
 
 test.beforeEach(async ({ page }) => {
     await page.goto("/rust/perspective-viewer/test/html/superstore-debug.html");
@@ -84,7 +89,7 @@ test.describe("GradientStops control", () => {
         const selector = stopsField(view, "gradient");
 
         await expect(selector).toBeVisible();
-        await expect(selector.locator(".gradient-stop-handle")).toHaveCount(2);
+        await compareInnerHTMLToSnapshot(selector);
         expect((await columnsConfig(view))["Sales"]?.gradient).toBeUndefined();
     });
 
@@ -211,9 +216,7 @@ test.describe("GradientStops control", () => {
         const selector = stopsField(view, "gradient");
 
         await expect(selector.locator(".gradient-stop-handle")).toHaveCount(3);
-        await expect(
-            selector.locator(".gradient-stop-handle input[type=color]").nth(1),
-        ).toHaveValue("#222222");
+        await compareInnerHTMLToSnapshot(selector);
 
         expect((await columnsConfig(view))["Sales"]?.gradient).toBe(
             "linear-gradient(to right, #111111 0%, #222222 50%, #333333 100%)",
@@ -257,18 +260,12 @@ test.describe("Restricted GradientStops (sign-split)", () => {
         const selector = stopsField(view, "fg_colors");
         await expect(selector).toBeVisible();
         await expect(selector.locator(".gradient-stop-handle")).toHaveCount(2);
+        await compareInnerHTMLToSnapshot(selector, ["initial"]);
 
         const grips = selector.locator(".gradient-stop-grip");
-        await expect(grips).toHaveCount(2);
-        await expect(grips.first()).toHaveClass(/disabled/);
-        await expect(grips.nth(1)).toHaveClass(/disabled/);
         const locks = selector.locator(".gradient-stop-lock");
-        await expect(locks).toHaveCount(2);
-        await expect(selector.locator(".gradient-stop-remove")).toHaveCount(0);
-        await expect(selector.locator(".color-label")).toHaveCount(0);
-
         await locks.first().click();
-        await expect(selector.locator(".gradient-stop-handle")).toHaveCount(2);
+        await compareInnerHTMLToSnapshot(selector, ["initial"]);
 
         const bar = selector.locator(".gradient-stops-bar");
         const box = (await bar.boundingBox())!;
@@ -284,7 +281,7 @@ test.describe("Restricted GradientStops (sign-split)", () => {
         expect((await columnsConfig(view))["Sales"]?.fg_colors).toBeUndefined();
 
         await bar.dblclick({ position: { x: box.width / 2, y: 4 } });
-        await expect(selector.locator(".gradient-stop-handle")).toHaveCount(2);
+        await compareInnerHTMLToSnapshot(selector, ["initial"]);
         expect((await columnsConfig(view))["Sales"]?.fg_colors).toBeUndefined();
     });
 
@@ -330,7 +327,7 @@ test.describe("Restricted GradientStops (sign-split)", () => {
 
         const selector = stopsField(view, "fg_colors");
         await expect(selector.locator(".gradient-stop-handle")).toHaveCount(2);
-        await expect(selector.locator(".gradient-stop-lock")).toHaveCount(2);
+        await compareInnerHTMLToSnapshot(selector);
     });
 
     test("an over-length restored value renders fully and is prunable", async ({
@@ -350,19 +347,12 @@ test.describe("Restricted GradientStops (sign-split)", () => {
         const selector = stopsField(view, "fg_colors");
         const handles = selector.locator(".gradient-stop-handle");
         await expect(handles).toHaveCount(3);
-        await expect(
-            selector.locator(".gradient-stop-grip.disabled"),
-        ).toHaveCount(3);
+        await compareInnerHTMLToSnapshot(selector, ["restored"]);
 
         const middle = handles.nth(1);
-        await expect(middle.locator(".gradient-stop-remove")).not.toHaveClass(
-            /disabled/,
-        );
         await middle.locator(".gradient-stop-remove").click();
         await expect(handles).toHaveCount(2);
-
-        await expect(selector.locator(".gradient-stop-remove")).toHaveCount(0);
-        await expect(selector.locator(".gradient-stop-lock")).toHaveCount(2);
+        await compareInnerHTMLToSnapshot(selector, ["pruned"]);
     });
 });
 
@@ -386,7 +376,7 @@ test.describe("Palette control", () => {
         const sidebar = view.columnSettingsSidebar.container;
         await expect(sidebar.locator(".palette-selector")).toHaveCount(0);
         await enableSeriesMode(view);
-        await expect(sidebar.locator(".palette-swatch")).toHaveCount(3);
+        await compareInnerHTMLToSnapshot(sidebar.locator(".palette-selector"));
 
         const config = (await columnsConfig(view))["State"];
         expect(config.string_color_mode).toBe("series");
@@ -476,9 +466,7 @@ test.describe("Palette control", () => {
         expect((await columnsConfig(view))["State"]).toEqual({
             string_color_mode: "background",
         });
-        await expect(colorField.locator("input[type=color]")).toHaveValue(
-            "#2771a8",
-        );
+        await compareInnerHTMLToSnapshot(colorField, ["background-default"]);
     });
 
     test("the add tile respects the schema's max", async ({ page }) => {
@@ -497,7 +485,9 @@ test.describe("Palette control", () => {
         }
 
         await expect(swatches).toHaveCount(6);
-        await expect(add).toHaveCount(0);
+        await compareInnerHTMLToSnapshot(sidebar.locator(".palette-selector"), [
+            "maxed",
+        ]);
     });
 
     test("dragging a swatch previews the order and commits on release; a press is a click", async ({
@@ -580,12 +570,9 @@ test.describe("Palette control", () => {
         const sidebar = view.columnSettingsSidebar.container;
         const swatches = sidebar.locator(".palette-swatch");
         await expect(swatches).toHaveCount(2);
-        await expect(swatches.nth(0).locator("input[type=color]")).toHaveValue(
-            "#123456",
-        );
-        await expect(swatches.nth(1).locator("input[type=color]")).toHaveValue(
-            "#654321",
-        );
+        await compareInnerHTMLToSnapshot(sidebar.locator(".palette-selector"), [
+            "restored",
+        ]);
 
         expect((await columnsConfig(view))["State"]?.palette).toBe(
             "linear-gradient(to right, #123456, #654321)",
@@ -696,19 +683,7 @@ test.describe("Named values (var() references + the workspace palette)", () => {
 
         const selector = stopsField(view, "gradient");
         await expect(selector.locator(".gradient-stop-handle")).toHaveCount(2);
-        await expect(selector.locator(".gradient-stop-grip")).toHaveCount(2);
-        await expect(
-            selector.locator(".gradient-stop-handle input[type=color]").first(),
-        ).toBeEnabled();
-
-        const controls = field(view, "gradient").locator(
-            ".named-value-controls",
-        );
-        await expect(controls.locator("select option")).toHaveText([
-            "Load",
-            "1",
-        ]);
-        await expect(controls.locator(".named-value-pin")).toBeVisible();
+        await compareInnerHTMLToSnapshot(field(view, "gradient"), ["widget"]);
     });
 
     test("a reference of the wrong kind rejects restore(); an unresolvable one renders the default", async ({
@@ -747,9 +722,13 @@ test.describe("Named values (var() references + the workspace palette)", () => {
         ).toBeUndefined();
         expect((await columnsConfig(view))["Sales"]?.gradient).toBeUndefined();
         expect((await saveWorkspace(view)).palette).toBeUndefined();
-        await expect(
-            stopsField(view, "gradient").locator(".gradient-stop-handle"),
-        ).toHaveCount(2);
+        await stopsField(view, "gradient")
+            .locator(".gradient-stop-handle")
+            .first()
+            .waitFor();
+        await compareInnerHTMLToSnapshot(stopsField(view, "gradient"), [
+            "default",
+        ]);
     });
 
     test("restoreWorkspace({palette}) defines, resolves and round-trips named values", async ({
@@ -905,10 +884,8 @@ test.describe("Named values (var() references + the workspace palette)", () => {
         const controls = field(view, "gradient").locator(
             ".named-value-controls",
         );
-        await expect(controls.locator("select option")).toHaveText([
-            "Load",
-            "1",
-        ]);
+        await controls.waitFor({ state: "attached" });
+        await compareInnerHTMLToSnapshot(controls, ["gradient-1"]);
 
         await input.fill("#0000ff");
         expect((await saveWorkspace(view)).palette).toEqual({
@@ -948,18 +925,13 @@ test.describe("Named values (var() references + the workspace palette)", () => {
         const profitControls = field(view, "gradient").locator(
             ".named-value-controls",
         );
-        await expect(profitControls.locator("select option")).toHaveText([
-            "Load",
-            "1",
-            "2",
-        ]);
+        await profitControls.waitFor({ state: "attached" });
+        await compareInnerHTMLToSnapshot(profitControls, ["profit-options"]);
         await profitControls.locator("select").selectOption("2");
         await expect(profitControls.locator("select")).toHaveValue("");
-        await expect(
-            stopsField(view, "gradient")
-                .locator(".gradient-stop-handle input[type=color]")
-                .first(),
-        ).toBeEnabled();
+        await compareInnerHTMLToSnapshot(stopsField(view, "gradient"), [
+            "profit-loaded",
+        ]);
         expect((await columnsConfig(view))["Profit"]?.gradient).toBe(
             "linear-gradient(to right, #0000ff 0%, #ff471e 100%)",
         );
@@ -1014,20 +986,13 @@ test.describe("Named values (var() references + the workspace palette)", () => {
         const controls = field(view, "palette").locator(
             ".named-value-controls",
         );
-        await expect(controls.locator("select option")).toHaveText([
-            "Load",
-            "1",
-        ]);
-        await expect(controls.locator(".named-value-pin")).toHaveCount(0);
+        await controls.waitFor({ state: "attached" });
+        await compareInnerHTMLToSnapshot(field(view, "palette"), ["initial"]);
 
         await controls.locator("select").selectOption("1");
         const swatches = sidebar.locator(".palette-swatch");
         await expect(swatches).toHaveCount(6);
-        await expect(
-            swatches.first().locator("input[type=color]"),
-        ).toBeEnabled();
-        await expect(sidebar.locator(".palette-add")).toHaveCount(0);
-        await expect(controls.locator("select")).toHaveValue("");
+        await compareInnerHTMLToSnapshot(field(view, "palette"), ["loaded"]);
 
         const SIX =
             "linear-gradient(to right, #111111, #222222, #333333, #444444, #555555, #666666)";
@@ -1039,11 +1004,10 @@ test.describe("Named values (var() references + the workspace palette)", () => {
         );
 
         await swatches.first().locator("input[type=color]").fill("#00ff00");
-        await expect(controls.locator("select option")).toHaveText([
-            "Load",
-            "2",
-            "1",
-        ]);
+        await controls
+            .locator("option", { hasText: "2" })
+            .waitFor({ state: "attached" });
+        await compareInnerHTMLToSnapshot(controls, ["renamed"]);
         workspace = await saveWorkspace(view);
         expect(Object.keys(workspace.palette)).toEqual([
             "--psp-user--palette-2",

--- a/rust/perspective-viewer/test/js/column_settings/sidebar.spec.ts
+++ b/rust/perspective-viewer/test/js/column_settings/sidebar.spec.ts
@@ -10,7 +10,13 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect, PageView, ColumnSettingsSidebar } from "../helpers.ts";
+import {
+    test,
+    expect,
+    PageView,
+    ColumnSettingsSidebar,
+    compareInnerHTMLToSnapshot,
+} from "../helpers.ts";
 
 test.beforeEach(async ({ page }) => {
     await page.goto("/rust/perspective-viewer/test/html/superstore-debug.html");
@@ -207,27 +213,24 @@ test.describe("Column Settings Sidebar", () => {
         await col.editBtn.click();
         await view.columnSettingsSidebar.openTab("Attributes");
         await checkTab(view.columnSettingsSidebar, false, true);
-        const selectedTab = async () => {
-            return await view.columnSettingsSidebar.selectedTab
-                .locator(".tab-title")
-                .getAttribute("id");
-        };
+        const tabBar =
+            view.columnSettingsSidebar.container.locator("#settings_tab_bar");
 
-        expect(await selectedTab()).toBe("Attributes");
+        await compareInnerHTMLToSnapshot(tabBar, ["inactive"]);
         await col.activeBtn.click();
         await view.columnSettingsSidebar.container
             .locator(".tab-title#Style")
             .waitFor({ state: "visible" });
 
         await checkTab(view.columnSettingsSidebar, true, true, true);
-        expect(await selectedTab()).toBe("Attributes");
+        await compareInnerHTMLToSnapshot(tabBar, ["activated"]);
         await view.columnSettingsSidebar.attributesTab.expressionEditor.textarea.clear();
         await view.columnSettingsSidebar.attributesTab.expressionEditor.textarea.type(
             "'new expr value'",
         );
 
         await view.columnSettingsSidebar.attributesTab.saveBtn.click();
-        expect(await selectedTab()).toBe("Attributes");
+        await compareInnerHTMLToSnapshot(tabBar, ["activated"]);
     });
 
     test("color range > resets to default when switching to a different number column", async ({
@@ -253,13 +256,10 @@ test.describe("Column Settings Sidebar", () => {
         await firstCol.editBtn.click();
         await checkTab(view.columnSettingsSidebar, true, false, false);
 
-        // expect style tab is selected
-        const selectedTab = async () => {
-            return await view.columnSettingsSidebar.selectedTab
-                .locator(".tab-title")
-                .getAttribute("id");
-        };
-        expect(await selectedTab()).toBe("Style");
+        await compareInnerHTMLToSnapshot(
+            view.columnSettingsSidebar.container.locator("#settings_tab_bar"),
+            ["style-selected"],
+        );
         const getFgColorNeg = async () => {
             return view.columnSettingsSidebar.styleTab.container
                 .locator("fieldset.style-control", {
@@ -270,10 +270,14 @@ test.describe("Column Settings Sidebar", () => {
         };
 
         let fgColorNeg = await getFgColorNeg();
-        expect(fgColorNeg).toBeTruthy();
-        expect(fgColorNeg).toBeVisible();
-        expect(fgColorNeg).toBeEditable();
-        expect(fgColorNeg).toHaveValue(defaultNegColor);
+        await expect(fgColorNeg).toBeVisible();
+        await compareInnerHTMLToSnapshot(
+            view.columnSettingsSidebar.styleTab.container.locator(
+                "fieldset.style-control",
+                { has: page.locator("#fg_colors-label") },
+            ),
+            ["default-colors"],
+        );
 
         // change -ve color from default
         await fgColorNeg.fill("#ffff00");

--- a/rust/perspective-viewer/test/js/column_settings/target.spec.ts
+++ b/rust/perspective-viewer/test/js/column_settings/target.spec.ts
@@ -10,7 +10,12 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect, PageView } from "../helpers.ts";
+import {
+    test,
+    expect,
+    PageView,
+    compareInnerHTMLToSnapshot,
+} from "../helpers.ts";
 
 test.describe("Column settings target", () => {
     test.beforeEach(async ({ page }) => {
@@ -46,10 +51,12 @@ test.describe("Column settings target", () => {
 
         const sidebar = new PageView(page).columnSettingsSidebar;
         await expect(sidebar.container).toBeVisible();
-        expect(await sidebar.getTabs()).toContain("Window");
+        await compareInnerHTMLToSnapshot(
+            sidebar.container.locator("#settings_tab_bar"),
+            ["tabs"],
+        );
         await sidebar.openTab("Window");
-        await expect(sidebar.nameInput).toBeEnabled();
-        await expect(sidebar.nameInput).toHaveValue("w1");
+        await compareInnerHTMLToSnapshot(sidebar.nameInputWrapper, ["header"]);
     });
 
     test("toggleColumnSettings on an unknown column closes the drawer", async ({

--- a/rust/perspective-viewer/test/js/helpers.ts
+++ b/rust/perspective-viewer/test/js/helpers.ts
@@ -93,6 +93,22 @@ export async function compareContentsToSnapshot(
     await expect(formatted).toMatchSnapshot(pathArray);
 }
 
+export async function compareInnerHTMLToSnapshot(
+    locator: Locator,
+    extraSnapshotPath?: string[],
+): Promise<void> {
+    const contents = await locator.evaluate((el) => el.innerHTML);
+    await compareContentsToSnapshot(contents, extraSnapshotPath);
+}
+
+export async function compareOuterHTMLToSnapshot(
+    locator: Locator,
+    extraSnapshotPath?: string[],
+): Promise<void> {
+    const contents = await locator.evaluate((el) => el.outerHTML);
+    await compareContentsToSnapshot(contents, extraSnapshotPath);
+}
+
 export async function compareNodes(
     left: Locator,
     right: Locator,

--- a/rust/perspective-viewer/test/js/multi_panel/context_menu_picker.spec.ts
+++ b/rust/perspective-viewer/test/js/multi_panel/context_menu_picker.spec.ts
@@ -12,15 +12,6 @@
 
 // Panel context-menu behaviors: picker host identity, theme-key styling,
 // and the shift+right-click native-menu passthrough.
-//
-// The context menu's Export/Copy format pickers swap in at the SAME vdom
-// position as the menu's `PortalModal`, whose host element and adopted
-// surface sheet are create-time-only. Unkeyed, Yew reused the menu's
-// component: the picker rendered inside the recycled
-// `<perspective-context-menu>` host with the context-menu sheet instead of
-// its own `<perspective-export-menu>`/`<perspective-copy-menu>` host with
-// the dropdown-menu sheet. The stages are now keyed by host tag; these
-// specs pin the host identity and its surface-sheet `:host` chrome.
 
 import { test, expect } from "../helpers.ts";
 import { armInvariants, assertCoherent } from "./harness.ts";
@@ -50,75 +41,22 @@ async function openPicker(page, label: string) {
 async function assertPickerSurface(page, tag: string) {
     const picker = page.locator(tag);
     await picker.waitFor();
-
-    // The picker must have its OWN host — the menu stage's host is gone.
     await expect(page.locator("perspective-context-menu")).toHaveCount(0);
     await expect(
         picker.locator(".dropdown-group-container").first(),
     ).toBeVisible();
 
-    // `:host` chrome only the dropdown-menu surface sheet provides — without
-    // it the host computes `display: inline` / `padding: 0px`.
     const style = await picker.evaluate((el) => {
         const cs = getComputedStyle(el);
         return { display: cs.display, padding: cs.padding };
     });
 
     expect(style).toEqual({ display: "flex", padding: "8px" });
-
-    // Blur-dismissal still ends the menu session on the fresh host.
     await picker.evaluate((el: HTMLElement) => el.blur());
     await expect(picker).toHaveCount(0);
 }
 
 test.describe("Context menu styling", () => {
-    // The menu's item hover must use the SAME theme keys as the Copy/Export
-    // pickers it spawns: the inverted `--psp--color`/`--psp--background-color`
-    // pair, which land on the host as computed `color`/`background-color` via
-    // the shared modal selector groups.
-    test("item hover uses the dropdown-menu inverted theme keys", async ({
-        page,
-    }) => {
-        await page
-            .locator("perspective-viewer perspective-viewer-plugin")
-            .first()
-            .click({ button: "right" });
-
-        const menu = page.locator("perspective-context-menu");
-        await menu.waitFor();
-        const item = menu.locator(".context-menu-item", {
-            hasText: "Duplicate",
-        });
-
-        await item.hover();
-        const styles = await item.evaluate((el) => {
-            const host = (el.getRootNode() as ShadowRoot).host;
-            const item_style = getComputedStyle(el);
-            const host_style = getComputedStyle(host);
-            return {
-                item: {
-                    background: item_style.backgroundColor,
-                    color: item_style.color,
-                },
-                host: {
-                    background: host_style.backgroundColor,
-                    color: host_style.color,
-                },
-            };
-        });
-
-        expect(styles.item.background).toEqual(styles.host.color);
-        expect(styles.item.color).toEqual(styles.host.background);
-
-        await menu.evaluate((el: HTMLElement) => el.blur());
-        await expect(menu).toHaveCount(0);
-        await assertCoherent(page);
-    });
-
-    // The submenu flyout is a CHILD of its hovered (inverted) parent item —
-    // un-hovered submenu rows must show the normal foreground, not the
-    // parent's inherited inverted one (which matches the flyout's own
-    // background).
     test("submenu items keep the normal foreground under a hovered parent", async ({
         page,
     }) => {
@@ -159,9 +97,6 @@ test.describe("Context menu styling", () => {
 });
 
 test.describe("Shift+right-click passthrough", () => {
-    // Record whether the viewer suppressed the native menu. Our own
-    // `preventDefault()` runs AFTER the flag is read and only keeps headed
-    // runs from opening a real browser menu.
     async function armContextMenuProbe(page) {
         await page.evaluate(() => {
             (window as any).__ctx_prevented = [];
@@ -185,8 +120,6 @@ test.describe("Shift+right-click passthrough", () => {
         await plugin.click({ button: "right", modifiers: ["Shift"] });
         expect(await preventedFlags(page)).toEqual([false]);
         await expect(page.locator("perspective-context-menu")).toHaveCount(0);
-
-        // Control: the unmodified right-click still opens the panel menu.
         await plugin.click({ button: "right" });
         await page.locator("perspective-context-menu").waitFor();
         expect(await preventedFlags(page)).toEqual([false, true]);
@@ -196,14 +129,9 @@ test.describe("Shift+right-click passthrough", () => {
     test("on a panel tab the native menu passes through", async ({ page }) => {
         await armContextMenuProbe(page);
         const tab = page.locator("perspective-viewer-tab").first();
-
         await tab.click({ button: "right", modifiers: ["Shift"] });
         expect(await preventedFlags(page)).toEqual([false]);
         await expect(page.locator("perspective-context-menu")).toHaveCount(0);
-
-        // Control: unmodified right-click opens the panel menu. The tab's
-        // handler `stopPropagation()`s, so the document probe records
-        // nothing for it.
         await tab.click({ button: "right" });
         await page.locator("perspective-context-menu").waitFor();
         expect(await preventedFlags(page)).toEqual([false]);

--- a/rust/perspective-viewer/test/js/multi_panel/workspace.spec.ts
+++ b/rust/perspective-viewer/test/js/multi_panel/workspace.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "../helpers.ts";
+import { test, expect, compareInnerHTMLToSnapshot } from "../helpers.ts";
 import { armInvariants } from "./harness.ts";
 
 const TABLE = "load-viewer-csv";
@@ -328,16 +328,7 @@ test.describe("Panel context menu", () => {
         // (like the Copy/Export menus), NOT a viewer descendant.
         const menu = page.locator("perspective-context-menu");
         await menu.waitFor();
-        await expect(menu.locator(".context-menu-item")).toContainText([
-            "New",
-            "Duplicate",
-            "Reset",
-            "Export",
-            "Copy",
-            "Maximize",
-            "Master",
-            "Close",
-        ]);
+        await compareInnerHTMLToSnapshot(menu);
 
         await menu
             .locator(".context-menu-item", { hasText: "Duplicate" })
@@ -377,12 +368,8 @@ test.describe("Panel context menu", () => {
         await new_item.hover();
         const submenu = new_item.locator(".context-menu-submenu");
         // Single client — a flat list of its hosted table names, no headers.
-        await expect(submenu.locator(".context-menu-item")).toContainText([
-            TABLE,
-            "second-table",
-        ]);
-
-        await expect(submenu.locator(".context-menu-header")).toHaveCount(0);
+        await submenu.waitFor();
+        await compareInnerHTMLToSnapshot(submenu);
         const prev_active = await page.evaluate(() =>
             // @ts-ignore
             document.querySelector("perspective-viewer")!.getActivePanel(),
@@ -450,11 +437,8 @@ test.describe("Panel context menu", () => {
         await new_item.hover();
         const submenu = new_item.locator(".context-menu-submenu");
         // Two clients — a header row per client, tables grouped beneath.
-        await expect(submenu.locator(".context-menu-header")).toHaveCount(2);
-        await expect(submenu.locator(".context-menu-item")).toContainText([
-            TABLE,
-            "other-client-table",
-        ]);
+        await submenu.waitFor();
+        await compareInnerHTMLToSnapshot(submenu);
 
         // "other-client-table" exists ONLY on the second client, so a
         // successful bind proves the sub-menu targeted the right client.

--- a/rust/perspective-viewer/test/js/settings_panel/control_groups.spec.ts
+++ b/rust/perspective-viewer/test/js/settings_panel/control_groups.spec.ts
@@ -1,0 +1,292 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { test, expect, PageView } from "../helpers.ts";
+import type { Locator } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("/rust/perspective-viewer/test/html/superstore-debug.html");
+    await page.evaluate(async () => {
+        while (!(window as any)["__TEST_PERSPECTIVE_READY__"]) {
+            await new Promise((x) => setTimeout(x, 10));
+        }
+    });
+});
+
+function pluginTab(view: PageView): Locator {
+    return view.container.locator("#plugin-tab");
+}
+
+async function openPluginTab(view: PageView) {
+    await view.container.locator("#plugin_tabbar_tab").click();
+    await pluginTab(view).waitFor({ state: "visible" });
+}
+
+async function openStyleTab(view: PageView, column: string) {
+    const col = await view.settingsPanel.activeColumns.getColumnByName(column);
+    await view.assureColumnSettingsOpen(col);
+    await view.columnSettingsSidebar.container.waitFor({ state: "visible" });
+}
+
+test.describe("Plugin tab control groups", () => {
+    test("group renders as a default-open collapsible section", async ({
+        page,
+    }) => {
+        const view = new PageView(page);
+        await view.restore({ settings: true, plugin: "Debug Styled" });
+        await openPluginTab(view);
+
+        const group = pluginTab(view).locator("details.control-group");
+        await expect(group).toHaveCount(1);
+        await expect(group).toHaveJSProperty("open", true);
+        await expect(group.locator("summary #legend-group-label")).toHaveCount(
+            1,
+        );
+
+        await expect(group.locator("#legend_on-label")).toHaveCount(1);
+        await expect(group.locator("#legend_width-label")).toHaveCount(1);
+        await expect(
+            pluginTab(view).locator("details.control-group #edit_mode-label"),
+        ).toHaveCount(0);
+        await expect(pluginTab(view).locator("#edit_mode-label")).toHaveCount(
+            1,
+        );
+    });
+
+    test("collapse survives a config-change re-render", async ({ page }) => {
+        const view = new PageView(page);
+        await view.restore({ settings: true, plugin: "Debug Styled" });
+        await openPluginTab(view);
+
+        const group = pluginTab(view).locator("details.control-group");
+        await group.locator("summary").click();
+        await expect(group).toHaveJSProperty("open", false);
+
+        await view.restore({ plugin_config: { edit_mode: "EDIT" } });
+        await expect(group).toHaveJSProperty("open", false);
+        await expect(group).toHaveCount(1);
+    });
+
+    test("editing a grouped field serializes flat", async ({ page }) => {
+        const view = new PageView(page);
+        await view.restore({ settings: true, plugin: "Debug Styled" });
+        await openPluginTab(view);
+
+        await pluginTab(view).locator("input#legend_on-checkbox").click();
+        const config = (await view.save()) as any;
+        expect(config.plugin_config).toEqual({ legend_on: true });
+    });
+
+    test("restore round-trip populates grouped controls", async ({ page }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Styled",
+            plugin_config: { legend_on: true, legend_width: 200 },
+        });
+
+        await openPluginTab(view);
+        const group = pluginTab(view).locator("details.control-group");
+        await expect(group.locator("input#legend_on-checkbox")).toBeChecked();
+
+        const config = (await view.save()) as any;
+        expect(config.plugin_config).toEqual({
+            legend_on: true,
+            legend_width: 200,
+        });
+    });
+});
+
+test.describe("Column Style tab control groups", () => {
+    test("numeric column renders the `fg` group and serializes flat", async ({
+        page,
+    }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Styled",
+            columns: ["Sales"],
+        });
+
+        await openStyleTab(view, "Sales");
+        const sidebar = view.columnSettingsSidebar.container;
+
+        await expect(sidebar.locator("details.control-group")).toHaveCount(3);
+        await expect(
+            sidebar.locator(
+                "details.control-group summary #format-group-label",
+            ),
+        ).toHaveCount(1);
+
+        const fg = sidebar.locator("details.control-group", {
+            has: page.locator("#fg-group-label"),
+        });
+
+        await expect(fg).toHaveJSProperty("open", true);
+        await expect(fg.locator("summary #fg-group-label")).toHaveCount(1);
+        await expect(fg.locator("#fg_flag-label")).toHaveCount(1);
+        await expect(fg.locator("#fg_color-label")).toHaveCount(1);
+
+        await fg.locator("input#fg_flag-checkbox").click();
+        const config = (await view.save()) as any;
+        expect(config.columns_config).toEqual({ Sales: { fg_flag: true } });
+    });
+
+    test("collapse survives the Style tab's revision re-render", async ({
+        page,
+    }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Styled",
+            columns: ["Sales"],
+        });
+
+        await openStyleTab(view, "Sales");
+        const sidebar = view.columnSettingsSidebar.container;
+        const fg = sidebar.locator("details.control-group", {
+            has: page.locator("#fg-group-label"),
+        });
+
+        await fg.locator("summary").click();
+        await expect(fg).toHaveJSProperty("open", false);
+
+        await view.restore({
+            columns_config: { Sales: { fg_flag: true } },
+        });
+
+        await expect(fg).toHaveJSProperty("open", false);
+        await expect(fg).toHaveCount(1);
+    });
+
+    test("shift+click applies the toggle to every section", async ({
+        page,
+    }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Styled",
+            columns: ["Sales"],
+        });
+
+        await openStyleTab(view, "Sales");
+        const sidebar = view.columnSettingsSidebar.container;
+        const fg = sidebar.locator("details.control-group", {
+            has: page.locator("#fg-group-label"),
+        });
+
+        const bg = sidebar.locator("details.control-group", {
+            has: page.locator("#bg-group-label"),
+        });
+
+        await bg.locator("summary").click();
+        await expect(bg).toHaveJSProperty("open", false);
+        await expect(fg).toHaveJSProperty("open", true);
+
+        await fg.locator("summary").click({ modifiers: ["Shift"] });
+        await expect(fg).toHaveJSProperty("open", false);
+        await expect(bg).toHaveJSProperty("open", false);
+
+        await fg.locator("summary").click({ modifiers: ["Shift"] });
+        await expect(fg).toHaveJSProperty("open", true);
+        await expect(bg).toHaveJSProperty("open", true);
+    });
+
+    test("chevron advertises the shift alternate action", async ({ page }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Styled",
+            columns: ["Sales"],
+        });
+
+        await openStyleTab(view, "Sales");
+        const sidebar = view.columnSettingsSidebar.container;
+        await expect(
+            sidebar.locator(
+                "details.control-group summary span.control-group-chevron.shift-alt-icon",
+            ),
+        ).toHaveCount(3);
+
+        await page.keyboard.down("Shift");
+        await expect(view.container).toHaveClass(/shift-active/);
+        await page.keyboard.up("Shift");
+        await expect(view.container).not.toHaveClass(/shift-active/);
+    });
+});
+
+test.describe("Control group collapse persistence", () => {
+    test("collapse survives a column switch and drawer re-open", async ({
+        page,
+    }) => {
+        const view = new PageView(page);
+        await view.restore({
+            settings: true,
+            plugin: "Debug Styled",
+            columns: ["Sales", "Profit"],
+        });
+
+        await openStyleTab(view, "Sales");
+        const sidebar = view.columnSettingsSidebar.container;
+        const fg = sidebar.locator("details.control-group", {
+            has: page.locator("#fg-group-label"),
+        });
+
+        const bg = sidebar.locator("details.control-group", {
+            has: page.locator("#bg-group-label"),
+        });
+
+        await fg.locator("summary").click();
+        await expect(fg).toHaveJSProperty("open", false);
+
+        await openStyleTab(view, "Profit");
+        await expect(fg).toHaveJSProperty("open", false);
+        await expect(bg).toHaveJSProperty("open", true);
+
+        await view.columnSettingsSidebar.closeBtn.click();
+        await sidebar.waitFor({ state: "hidden" });
+        await openStyleTab(view, "Sales");
+        await expect(fg).toHaveJSProperty("open", false);
+        await expect(bg).toHaveJSProperty("open", true);
+    });
+
+    test("plugin tab collapse survives a settings-panel toggle", async ({
+        page,
+    }) => {
+        const view = new PageView(page);
+        await view.restore({ settings: true, plugin: "Debug Styled" });
+        await openPluginTab(view);
+
+        const group = pluginTab(view).locator("details.control-group");
+        await group.locator("summary").click();
+        await expect(group).toHaveJSProperty("open", false);
+
+        await view.restore({ settings: false });
+        await view.restore({ settings: true });
+        await openPluginTab(view);
+        await expect(group).toHaveJSProperty("open", false);
+    });
+
+    test("group state does not serialize into save()", async ({ page }) => {
+        const view = new PageView(page);
+        await view.restore({ settings: true, plugin: "Debug Styled" });
+        await openPluginTab(view);
+
+        const group = pluginTab(view).locator("details.control-group");
+        await group.locator("summary").click();
+        await expect(group).toHaveJSProperty("open", false);
+
+        const config = (await view.save()) as any;
+        expect(config.plugin_config).toEqual({});
+        expect(config.legend).toBeUndefined();
+    });
+});

--- a/rust/perspective-viewer/test/js/viewer_api/load.spec.ts
+++ b/rust/perspective-viewer/test/js/viewer_api/load.spec.ts
@@ -14,6 +14,7 @@ import {
     test,
     expect,
     compareContentsToSnapshot,
+    getLightContents,
     getShadowContents,
 } from "../helpers.ts";
 
@@ -29,7 +30,8 @@ test.describe("Viewer Load", () => {
             const goodTable = (await window.WORKER).table("a,b,c\n1,2,3");
             return viewer.load(goodTable);
         });
-        await expect(viewer).toHaveText(/"a","b","c"/); // column titles
+        await expect(viewer).toHaveText(/"a","b","c"/);
+        await compareContentsToSnapshot(await getLightContents(page));
     });
 
     test("load(client) > the first restore applies element-level settings", async ({

--- a/rust/perspective-viewer/test/js/windows.spec.ts
+++ b/rust/perspective-viewer/test/js/windows.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "./helpers.ts";
+import { test, expect, compareInnerHTMLToSnapshot } from "./helpers.ts";
 
 test.describe("Window columns", () => {
     test.beforeEach(async function init({ page }) {
@@ -428,9 +428,7 @@ test.describe("Window columns", () => {
         await expect(
             page.locator("#window-source .column-empty-input"),
         ).toBeVisible();
-        await expect(page.locator(".window-editor-error")).toContainText(
-            "Missing Column",
-        );
+        await compareInnerHTMLToSnapshot(page.locator("#window-tab"));
     });
 
     test("partition pill moved to a slot does not duplicate", async ({
@@ -514,7 +512,7 @@ test.describe("Window columns", () => {
         await expect(
             page.locator("#window-source .column-selector-draggable"),
         ).toContainText("Sales");
-        await expect(page.locator(".window-editor-error")).toHaveCount(0);
+        await compareInnerHTMLToSnapshot(page.locator("#window-tab"));
 
         // A no-op drop leaves the draft equal to the saved spec, so the
         // change-gated Save stays disabled and the saved config is intact.
@@ -607,16 +605,15 @@ test.describe("Window columns", () => {
             "#window-source .aggregate-selector-wrapper select",
         );
         await expect(select).toHaveValue("count");
-        expect(await select.locator("option").allTextContents()).toEqual([
-            "count",
-            "min",
-            "max",
-            "lag",
-            "lead",
-        ]);
+        await select
+            .locator("option", { hasText: "lead" })
+            .waitFor({ state: "attached" });
+
         // No error at all: the coerced op is valid for the string source,
         // and the empty order slot is a valid natural-order draft.
-        await expect(page.locator(".window-editor-error")).toHaveCount(0);
+        await compareInnerHTMLToSnapshot(page.locator("#window-tab"), [
+            "string-source",
+        ]);
 
         // A numeric source restores the full op list; the user's (still
         // valid) op choice is preserved.
@@ -626,19 +623,12 @@ test.describe("Window columns", () => {
         );
 
         await expect(select).toHaveValue("count");
-        expect(await select.locator("option").allTextContents()).toEqual([
-            "sum",
-            "avg",
-            "count",
-            "min",
-            "max",
-            "stddev",
-            "var",
-            "lag",
-            "lead",
-            "diff",
-            "rate",
-            "ema",
+        await select
+            .locator("option", { hasText: "stddev" })
+            .waitFor({ state: "attached" });
+
+        await compareInnerHTMLToSnapshot(page.locator("#window-tab"), [
+            "numeric-source",
         ]);
     });
 

--- a/tools/scripts/sh_perspective.mjs
+++ b/tools/scripts/sh_perspective.mjs
@@ -13,7 +13,8 @@
 import * as dotenv from "dotenv";
 import * as path from "path";
 import * as fs from "fs";
-import { execSync } from "child_process";
+import { spawn } from "child_process";
+import * as os from "os";
 
 import "zx/globals";
 
@@ -105,11 +106,73 @@ export function get_scope() {
     return packages;
 }
 
+const CANCEL_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"];
+
+const CANCEL_GRACE_MS = 4_000;
+
+function run_cancellable(cmd, args) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(cmd, args, {
+            stdio: ["ignore", "inherit", "inherit"],
+            detached: true,
+        });
+
+        let cancelled;
+        let escalation;
+        const signal_group = (signal) => {
+            try {
+                process.kill(-child.pid, signal);
+            } catch {}
+        };
+
+        const cancel = (signal) => {
+            if (cancelled) {
+                signal_group("SIGKILL");
+                return;
+            }
+
+            cancelled = signal;
+            signal_group("SIGTERM");
+            escalation = setTimeout(
+                () => signal_group("SIGKILL"),
+                CANCEL_GRACE_MS,
+            );
+            escalation.unref();
+        };
+
+        for (const signal of CANCEL_SIGNALS) {
+            process.on(signal, cancel);
+        }
+
+        child.on("error", reject);
+        child.on("exit", (code, signal) => {
+            clearTimeout(escalation);
+            for (const s of CANCEL_SIGNALS) {
+                process.off(s, cancel);
+            }
+
+            if (cancelled) {
+                process.kill(process.pid, cancelled);
+            } else if (signal) {
+                process.exit(128 + (os.constants.signals[signal] ?? 0));
+            } else if (code !== 0) {
+                process.exit(code);
+            } else {
+                resolve();
+            }
+        });
+    });
+}
+
 export const run_with_scope = async function run_recursive(strings, ...args) {
     let scope = get_scope();
     const cmd = strings[0].split(" ")[0];
-    const filters = scope.map((x) => `--filter ${x} --if-present`).join(" ");
-    execSync(`pnpm run --sequential --recursive ${filters} ${cmd}`, {
-        stdio: "inherit",
-    });
+    const filters = scope.flatMap((x) => ["--filter", x, "--if-present"]);
+    await run_cancellable("pnpm", [
+        "run",
+        "--sequential",
+        "--recursive",
+        ...filters,
+        cmd,
+    ]);
 };


### PR DESCRIPTION
This PR updates Tooltips for the `@perspective-dev/viewer-charts` package:

* Tooltips use consistent formatting from the Column Settings menu's `Format` group (see below).
* Tooltips now internally support tables, so labels and values are now aligned properly with conservative overflow, configurable via `column_config`.
* Tooltips now project intersection target labels against their axes (which also follow the configured `Format`).
* Tooltip themes work consistently and opacity is also configurable in `plugin_config`.

<img width="600" alt="" src="https://github.com/user-attachments/assets/3d85e32f-33c6-46e4-836d-4ffae9255869" />
<br/><br/>

Additionally, a new `ControlSpec::Group` type has been added to `plugin_config` and `columns_config` APIs, which allows grouping similar config settings into collapsing panels.  Panels can be shift+clicked to expand/collapse all (like in the Datagrid), and the state is persistent within the component. I reserve the option to make "closed" the default in the future if this panel becomes unwieldy, but it is still possible to add top-level components that cannot be hidden (as before).


<img width="548" height="439" alt="" src="https://github.com/user-attachments/assets/a8250038-31ad-4941-972f-38ca8badff82" />

### Drive-bys

* Fixes #1346
* Fixes a flakey mirror in the C++ cmake dep resolution which was decimating CI.
* Fixed ctrl-C zombify-ing processes in the toolchain.
* Moved ~40 tests which asserted DOM conditions to record tests.
* Fixed default theme bleed from the Light theme.
